### PR TITLE
some windows fixes

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -58,7 +58,7 @@ end
 
 # add Julia kernel manager if we don't have one yet
 add_config("ipython_config.py", "KernelManager.kernel_cmd",
-           """["$(joinpath(JULIA_HOME,"julia-basic"))", "$(joinpath(Pkg2.dir("IJulia"),"src","kernel.jl"))", "{connection_file}"]""")
+           """["$(escape_string(joinpath(JULIA_HOME,(@windows?"julia.bat":"julia-basic"))))", "$(escape_string(joinpath(Pkg2.dir("IJulia"),"src","kernel.jl")))", "{connection_file}"]""")
 
 # make qtconsole require shift-enter to complete input
 add_config("ipython_qtconsole_config.py",

--- a/src/heartbeat.jl
+++ b/src/heartbeat.jl
@@ -13,10 +13,10 @@ end
 
 function start_heartbeat(sock)
     heartbeat_c = cfunction(heartbeat_thread, Void, (Ptr{Void},))
-    if OS_NAME===:Windows
+    @windows? begin
         ccall(:_beginthread, Int, (Ptr{Void}, Cuint, Ptr{Void}),
               heartbeat_c, 0, sock.data)
-    else
+    end : begin
         threadid = Array(Int, 128) # sizeof(pthread_t) is <= 8 on Linux & OSX
         ccall((:pthread_create, :libpthread), Cint,
               (Ptr{Int}, Ptr{Void}, Ptr{Void}, Ptr{Void}),


### PR DESCRIPTION
With this I'm able to get IJulia up and running, but still can't do any computation (this is using the ZMQ from Anaconda, next I'll try compiling my own). One perhaps interesting tidbit:

```
Traceback (most recent call last):
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 303, in wrappe
r
    return callback(*args, **kwargs)
  File "C:\Anaconda\lib\site-packages\IPython\html\services\kernels\handlers.py"
, line 103, in on_first_message
    self.close()
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 213, in close
    self.ws_connection.close()
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 761, in close
    self.stream.io_loop.time() + 5, self._abort)
AttributeError: 'IOLoop' object has no attribute 'time'
2013-09-10 21:12:31.477 [tornado.application] ERROR | Uncaught exception in /ker
nels/5d118333-7bed-48eb-8b39-df9a27a5bbc1/stdin
Traceback (most recent call last):
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 303, in wrappe
r
    return callback(*args, **kwargs)
  File "C:\Anaconda\lib\site-packages\IPython\html\services\kernels\handlers.py"
, line 103, in on_first_message
    self.close()
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 213, in close
    self.ws_connection.close()
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 761, in close
    self.stream.io_loop.time() + 5, self._abort)
AttributeError: 'IOLoop' object has no attribute 'time'
2013-09-10 21:12:31.480 [tornado.application] ERROR | Uncaught exception in /ker
nels/5d118333-7bed-48eb-8b39-df9a27a5bbc1/iopub
Traceback (most recent call last):
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 303, in wrappe
r
    return callback(*args, **kwargs)
  File "C:\Anaconda\lib\site-packages\IPython\html\services\kernels\handlers.py"
, line 103, in on_first_message
    self.close()
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 213, in close
    self.ws_connection.close()
  File "C:\Anaconda\lib\site-packages\tornado\websocket.py", line 761, in close
    self.stream.io_loop.time() + 5, self._abort)
AttributeError: 'IOLoop' object has no attribute 'time'
Starting kernel event loops.
```

Don't think that's the main source of our problems though. Will keep investigating.
