### PR TITLE
Enable syntax highlighting in the QT Console

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -84,6 +84,9 @@ add_config("ipython_config.py", "KernelManager.kernel_cmd",
 add_config("ipython_qtconsole_config.py",
            "IPythonWidget.execute_on_complete_input", "False")
 
+add_config("ipython_qtconsole_config.py",
+           "FrontendWidget.lexer_class", "'pygments.lexers.JuliaLexer'")
+
 # set Julia notebook to use a different port than IPython's 8888 by default
 add_config("ipython_notebook_config.py", "NotebookApp.port", 8998)
 


### PR DESCRIPTION
With IPython master, this does make Julia syntax highlighting work (although not autoindent, for unclear reasons). IPython 1.1 doesn't have the lexer_class configuration property, so this is a no-op. 
