### PR TITLE
Add space to fix incorrect macro call.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -77,7 +77,7 @@ end
 
 # add Julia kernel manager if we don't have one yet
 add_config("ipython_config.py", "KernelManager.kernel_cmd",
-           """["$(escape_string(joinpath(JULIA_HOME,(@windows?(VERSION >= v"0.3-"?"julia-basic.exe":"julia.bat"):"julia-basic"))))", "-F", "$(escape_string(joinpath(Pkg.dir("IJulia"),"src","kernel.jl")))", "{connection_file}"]""",
+           """["$(escape_string(joinpath(JULIA_HOME,(@windows? (VERSION >= v"0.3-"?"julia-basic.exe":"julia.bat"):"julia-basic"))))", "-F", "$(escape_string(joinpath(Pkg.dir("IJulia"),"src","kernel.jl")))", "{connection_file}"]""",
            true)
 
 # make qtconsole require shift-enter to complete input


### PR DESCRIPTION
Previously, `Pkg.add("IJulia")` or `julia deps/build.jl` failed with an error message, the meat of which was
"wrong number of arguments while loading /home/christopher/.julia/v0.3/IJulia/deps/build.jl, in expression starting on line 79".

This was ultimately caused by the fact that the macro name @windows? was immediately followed by an open parenthesis. The parentheses were intended to mark the _first_ argument of @windows?---this argument itself is a nontrivial expression---but instead, because there was no space, Julia expected all the arguments to be inside the parentheses. Adding a space fixes this problem (see http://docs.julialang.org/en/release-0.2/manual/metaprogramming/#macros).
