### PR TITLE
Dup plots patch

### DIFF
--- a/src/inline.jl
+++ b/src/inline.jl
@@ -43,12 +43,16 @@ end
 # an input cell has finished executing.
 
 function in_repr(x, queue)
-    for item in queue
-        if x.o[:__repr__]() == item.o[:__repr__]()
-            return true
+    try
+        for item in queue
+            if x.o[:__repr__]() == item.o[:__repr__]()
+                return true
+            end
         end
+        return false
+    catch
+        return (x in queue)
     end
-    return false
 end
 
 function redisplay(d::InlineDisplay, x)


### PR DESCRIPTION
Patch to fix stevengj/PyPlot.jl#52. I'm not sure this is a very good and general way to do it, but I've at least found the problem, and perhaps this could be a platform for discussing a proper fix.

The issue is that with the hashing changes in Julia, the `redisplay` function no longer notices when a Figure type is already in the display queue. I suppose that properly hashing python objects is the real issue.

The fix here is to compare the output from the Python `__repr__` method, and fall back to the normal Julia equality test for types that aren't derived from Python.

Advice as to how to do this properly appreciated.
