### PR TITLE
Allow modules to attach metadata in IPython display_data & pyout messages

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -18,6 +18,10 @@ else
     mimewritable_(mime, x) = mimewritable(mime, typeof(x))
 end
 
+# return a String=>Any dictionary to attach as metadata
+# in IPython display_data and pyout messages
+metadata(x) = Dict()
+
 # return a String=>String dictionary of mimetype=>data for passing to
 # IPython display_data and pyout messages.
 function display_dict(x)
@@ -174,7 +178,7 @@ function execute_request_0x535c5df2(socket, msg)
             send_ipython(publish, 
                          msg_pub(msg, "pyout",
                                  ["execution_count" => _n,
-                                 "metadata" => Dict(), # qtconsole needs this
+                                 "metadata" => metadata(result), # qtconsole needs this
                                  "data" => display_dict(result) ]))
         end
         

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -18,7 +18,7 @@ for mime in ipy_mime
             send_ipython(publish, 
                          msg_pub(execute_msg, "display_data",
                                  ["source" => "julia", # optional
-                                  "metadata" => Dict(), # optional
+                                  "metadata" => metadata(x), # optional
                                   "data" => [$mime => stringmime(MIME($mime), x)] ]))
         end
     end
@@ -34,7 +34,7 @@ function display(d::InlineDisplay, x)
     send_ipython(publish, 
                  msg_pub(execute_msg, "display_data",
                          ["source" => "julia", # optional
-                          "metadata" => Dict(), # optional
+                          "metadata" => metadata(x), # optional
                           "data" => display_dict(x) ]))
 end
 


### PR DESCRIPTION
Fixes #182
(modules can now override display_dict _and_ metadata)
