### PR TITLE
Update stdio.jl

### DIFF
--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -49,9 +49,10 @@ function watch_stream(rd::IO, name::String)
     end
 end
 
-const read_stdin, write_stdin = redirect_stdin()
-const read_stdout, write_stdout = redirect_stdout()
-const read_stderr, write_stderr = redirect_stderr()
+# reflecting #7319
+const (read_stdin, write_stdin) = redirect_stdin()
+const (read_stdout, write_stdout) = redirect_stdout()
+const (read_stderr, write_stderr) = redirect_stderr()
 
 # IJulia issue #42: there doesn't seem to be a good way to make a task
 # that blocks until there is a read request from STDIN ... this makes


### PR DESCRIPTION
this is reflecting JuliaLang/julia#7319. since commit 135f2fb, const is using the same declarative syntax as global and local.

[pao: fix crosslink to JuilaLang/julia]
