### PR TITLE
core module is at the same level of directory

### DIFF
--- a/python/julia/__init__.py
+++ b/python/julia/__init__.py
@@ -1,3 +1,3 @@
 """Julia/IPython bridge."""
 
-from core import Julia
+from .core import Julia


### PR DESCRIPTION
solve the "ImportError: No module named 'core' " message
