### PR TITLE
Update Dict construction to reflect new syntax

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -28,7 +28,7 @@ function init(args)
     else
         # generate profile and save
         let port0 = 5678
-            global const profile = (String=>Any)[
+            global const profile = Dict{String,Any}(
                 "ip" => "127.0.0.1",
                 "transport" => "tcp",
                 "stdin_port" => port0,
@@ -37,7 +37,7 @@ function init(args)
                 "shell_port" => port0+3,
                 "iopub_port" => port0+4,
                 "key" => uuid4()
-            ]
+            )
             fname = "profile-$(getpid()).json"
             println("connect ipython with --existing $(pwd())/$fname")
             open(fname, "w") do f
@@ -124,10 +124,10 @@ function eventloop(socket)
                     send_ipython(publish, 
                                  execute_msg == nothing ?
                                  Msg([ "pyerr" ],
-                                     [ "msg_id" => uuid4(),
-                                     "username" => "jlkernel",
-                                     "session" => uuid4(),
-                                      "msg_type" => "pyerr" ], content) :
+                                     Dict( "msg_id" => uuid4(),
+                                           "username" => "jlkernel",
+                                           "session" => uuid4(),
+                                           "msg_type" => "pyerr" ), content) :
                                  msg_pub(execute_msg, "pyerr", content)) 
                 end
             finally

--- a/src/comm_manager.jl
+++ b/src/comm_manager.jl
@@ -46,8 +46,8 @@ comm_target{target}(comm :: Comm{target}) = target
 function msg_comm(comm::Comm, m::IJulia.Msg, msg_type,
                   data=Dict{String,Any}(),
                   metadata=Dict{String, Any}(); kwargs...)
-    content = ["comm_id"=>comm.id,
-               "data"=>data]
+    content = Dict("comm_id"=>comm.id,
+                   "data"=>data)
 
     for (k, v) in kwargs
         content[string(k)] = v

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -25,8 +25,8 @@ metadata(x) = Dict()
 # return a String=>String dictionary of mimetype=>data for passing to
 # IPython display_data and pyout messages.
 function display_dict(x)
-    data = (ASCIIString=>ByteString)[ "text/plain" => 
-                                          sprint(writemime, "text/plain", x) ]
+    data = Dict{ASCIIString,ByteString}( "text/plain" =>
+                                          sprint(writemime, "text/plain", x) )
     if mimewritable_(image_svg, x)
         data[string(image_svg)] = stringmime(image_svg, x)
     end
@@ -80,9 +80,9 @@ function pyerr_content(e, msg::String="")
     if !isempty(msg)
         unshift!(tb, msg)
     end
-    ["execution_count" => _n,
-     "ename" => ename, "evalue" => evalue,
-     "traceback" => tb]
+    Dict("execution_count" => _n,
+         "ename" => ename, "evalue" => evalue,
+         "traceback" => tb)
 end
 
 #######################################################################
@@ -107,7 +107,7 @@ pop_posterror_hook(f::Function) = splice!(posterror_hooks, findfirst(posterror_h
 #######################################################################
 
 # global variable so that display can be done in the correct Msg context
-execute_msg = Msg(["julia"], ["username"=>"julia", "session"=>"????"], Dict())
+execute_msg = Msg(["julia"], Dict("username"=>"julia", "session"=>"????"), Dict())
 
 # note: 0x535c5df2 is a random integer to make name collisions in
 # backtrace analysis less likely.
@@ -127,8 +127,8 @@ function execute_request_0x535c5df2(socket, msg)
     end
     send_ipython(publish, 
                  msg_pub(msg, "pyin",
-                         ["execution_count" => _n,
-                          "code" => code]))
+                         Dict("execution_count" => _n,
+                              "code" => code)))
 
     # "; ..." cells are interpreted as shell commands for run
     code = replace(code, r"^\s*;.*$", 
@@ -188,17 +188,17 @@ function execute_request_0x535c5df2(socket, msg)
 
             send_ipython(publish,
                          msg_pub(msg, "pyout",
-                                 ["execution_count" => _n,
-                                 "metadata" => result_metadata,
-                                 "data" => display_dict(result) ]))
+                                 Dict("execution_count" => _n,
+                                      "metadata" => result_metadata,
+                                      "data" => display_dict(result) )))
         end
         
         send_ipython(requests,
                      msg_reply(msg, "execute_reply",
-                               ["status" => "ok", "execution_count" => _n,
-                               "payload" => [],
-                               "user_variables" => user_variables,
-                                "user_expressions" => user_expressions]))
+                               Dict("status" => "ok", "execution_count" => _n,
+                                    "payload" => [],
+                                    "user_variables" => user_variables,
+                                    "user_expressions" => user_expressions)))
     catch e
         try
             # flush pending stdio

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -12,30 +12,30 @@ function complete_request(socket, msg)
     if sizeof(text) > length(positions)
         comps = [line[(cursorpos-sizeof(text)+1):(cursorpos-length(positions))]*s for s in comps]
     end
-    send_ipython(requests, msg_reply(msg, "complete_reply", [
+    send_ipython(requests, msg_reply(msg, "complete_reply", Dict(
         "status" => "ok",
         "matches" => comps,
         "matched_text" => line[positions],
-    ]))
+    )))
 end
 
 function kernel_info_request(socket, msg)
     send_ipython(requests,
                  msg_reply(msg, "kernel_info_reply",
-                           ["protocol_version" => [4, 0],
-                            "language_version" => [VERSION.major,
-                                                   VERSION.minor,
-                                                   VERSION.patch],
-                            "language" => "julia" ]))
+                           Dict("protocol_version" => [4, 0],
+                                "language_version" => [VERSION.major,
+                                                       VERSION.minor,
+                                                       VERSION.patch],
+                                "language" => "julia" )))
 end
 
 function connect_request(socket, msg)
     send_ipython(requests,
                  msg_reply(msg, "connect_reply",
-                           ["shell_port" => profile["shell_port"],
-                            "iopub_port" => profile["iopub_port"],
-                            "stdin_port" => profile["stdin_port"],
-                            "hb_port" => profile["hb_port"]]))
+                           Dict("shell_port" => profile["shell_port"],
+                                "iopub_port" => profile["iopub_port"],
+                                "stdin_port" => profile["stdin_port"],
+                                "hb_port" => profile["hb_port"])))
 end
 
 function shutdown_request(socket, msg)
@@ -52,15 +52,15 @@ function object_info_request(socket, msg)
     try
         s = parse(msg.content["oname"])
         o = eval(Main, s)
-        content = ["oname" => msg.content["oname"],
-                   "found" => true,
-                   "ismagic" => false,
-                   "isalias" => false,
-                   "docstring" => docstring(o),
-                   "type_name" => string(typeof(o)),
-                   "base_class" => string(typeof(o).super),
-                   "string_form" => get(msg.content,"detail_level",0) == 0 ? 
-                   sprint(16384, show, o) : repr(o) ]
+        content = Dict("oname" => msg.content["oname"],
+                       "found" => true,
+                       "ismagic" => false,
+                       "isalias" => false,
+                       "docstring" => docstring(o),
+                       "type_name" => string(typeof(o)),
+                       "base_class" => string(typeof(o).super),
+                       "string_form" => get(msg.content,"detail_level",0) == 0 ?
+                           sprint(16384, show, o) : repr(o) )
         if method_exists(length, (typeof(o),))
             content["length"] = length(o)
         end
@@ -69,8 +69,8 @@ function object_info_request(socket, msg)
         @verror_show e catch_backtrace()
         send_ipython(requests,
                      msg_reply(msg, "object_info_reply",
-                               ["oname" => msg.content["oname"],
-                                "found" => false ]))
+                               Dict("oname" => msg.content["oname"],
+                                    "found" => false )))
     end
 end
 
@@ -79,11 +79,11 @@ function history_request(socket, msg)
     # as requested in ipython/ipython#3806
     send_ipython(requests,
                  msg_reply(msg, "history_reply",
-                           ["history" => []]))
+                           Dict("history" => [])))
                              
 end
 
-const handlers = (String=>Function)[
+const handlers = Dict{String,Function}(
     "execute_request" => execute_request_0x535c5df2,
     "complete_request" => complete_request,
     "kernel_info_request" => kernel_info_request,
@@ -94,4 +94,4 @@ const handlers = (String=>Function)[
     "comm_open" => comm_open,
     "comm_msg" => comm_msg,
     "comm_close" => comm_close
-]
+)

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -18,9 +18,9 @@ for mime in ipy_mime
         function display(d::InlineDisplay, ::MIME{symbol($mime)}, x)
             send_ipython(publish, 
                          msg_pub(execute_msg, "display_data",
-                                 ["source" => "julia", # optional
-                                  "metadata" => metadata(x), # optional
-                                  "data" => [$mime => stringmime(MIME($mime), x)] ]))
+                                 Dict("source" => "julia", # optional
+                                      "metadata" => metadata(x), # optional
+                                      "data" => Dict($mime => stringmime(MIME($mime), x)) )))
         end
     end
 end
@@ -34,9 +34,9 @@ function display(d::InlineDisplay, x)
     undisplay(x) # dequeue previous redisplay(x)
     send_ipython(publish, 
                  msg_pub(execute_msg, "display_data",
-                         ["source" => "julia", # optional
-                          "metadata" => metadata(x), # optional
-                          "data" => display_dict(x) ]))
+                         Dict("source" => "julia", # optional
+                              "metadata" => metadata(x), # optional
+                              "data" => display_dict(x) )))
 end
 
 # we overload redisplay(d, x) to add x to a queue of objects to display,

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -22,18 +22,18 @@ end
 # subscribers currently subscribe to all topics".]
 msg_pub(m::Msg, msg_type, content, metadata=Dict{String,Any}()) =
   Msg([ msg_type == "stream" ? content["name"] : msg_type ], 
-      ["msg_id" => uuid4(),
-       "username" => m.header["username"],
-       "session" => m.header["session"],
-       "msg_type" => msg_type],
+      Dict("msg_id" => uuid4(),
+           "username" => m.header["username"],
+           "session" => m.header["session"],
+           "msg_type" => msg_type),
       content, m.header, metadata)
 
 msg_reply(m::Msg, msg_type, content, metadata=Dict{String,Any}()) =
   Msg(m.idents, 
-      ["msg_id" => uuid4(),
-       "username" => m.header["username"],
-       "session" => m.header["session"],
-       "msg_type" => msg_type],
+      Dict("msg_id" => uuid4(),
+           "username" => m.header["username"],
+           "session" => m.header["session"],
+           "msg_type" => msg_type),
       content, m.header, metadata)
 
 function show(io::IO, msg::Msg)
@@ -88,20 +88,20 @@ function send_status(state::String, parent_header=nothing)
     if parent_header == nothing
         msg = Msg(
             [ "status" ],
-            [ "msg_id" => uuid4(),
-             "username" => "jlkernel",
-             "session" => execute_msg.header["session"],
-             "msg_type" => "status" ],
-            [ "execution_state" => state ]
+            Dict( "msg_id" => uuid4(),
+                  "username" => "jlkernel",
+                  "session" => execute_msg.header["session"],
+                  "msg_type" => "status" ),
+            Dict( "execution_state" => state )
         )
     else
         msg = Msg(
             [ "status" ],
-            [ "msg_id" => uuid4(),
-             "username" => "jlkernel",
-             "session" => execute_msg.header["session"],
-             "msg_type" => "status" ],
-            [ "execution_state" => state ],
+            Dict( "msg_id" => uuid4(),
+                  "username" => "jlkernel",
+                  "session" => execute_msg.header["session"],
+                  "msg_type" => "status" ),
+            Dict( "execution_state" => state ),
             parent_header
         )
     end

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -23,7 +23,7 @@ function send_stream(s::String, name::String)
     if !isempty(s)
         send_ipython(publish,
                      msg_pub(execute_msg, "stream",
-                             ["name" => name, "data" => s]))
+                             Dict("name" => name, "data" => s)))
     end
 end
 
@@ -63,7 +63,7 @@ function readline(io::Base.Pipe)
         end
         send_ipython(raw_input,
                      msg_reply(execute_msg, "input_request",
-                               ["prompt" => "STDIN> "]))
+                               Dict("prompt" => "STDIN> ")))
         while true
             msg = recv_ipython(raw_input)
             if msg.header["msg_type"] == "input_reply"


### PR DESCRIPTION
Julia 0.4 changes the syntax for constructing Dicts; this commit
updates the package to use the new syntax. I think I've found all of
the places where it shows up and I get no deprecation warnings from
IJulia when I load it now.
