### PR TITLE
Update Dict construction to reflect new syntax

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,3 +3,4 @@ Nettle
 JSON 0.2-
 ZMQ 0.1-
 REPLCompletions
+Compat

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -6,6 +6,7 @@ function set_verbose(v=true)
     global verbose::Bool = v
 end
 
+using Compat
 using ZMQ
 using JSON
 using Nettle
@@ -28,7 +29,7 @@ function init(args)
     else
         # generate profile and save
         let port0 = 5678
-            global const profile = (String=>Any)[
+            global const profile = Dict{String,Any}([
                 "ip" => "127.0.0.1",
                 "transport" => "tcp",
                 "stdin_port" => port0,
@@ -37,7 +38,7 @@ function init(args)
                 "shell_port" => port0+3,
                 "iopub_port" => port0+4,
                 "key" => uuid4()
-            ]
+            ])
             fname = "profile-$(getpid()).json"
             println("connect ipython with --existing $(pwd())/$fname")
             open(fname, "w") do f
@@ -124,10 +125,10 @@ function eventloop(socket)
                     send_ipython(publish, 
                                  execute_msg == nothing ?
                                  Msg([ "pyerr" ],
-                                     [ "msg_id" => uuid4(),
+                                     @Compat.Dict("msg_id" => uuid4(),
                                      "username" => "jlkernel",
                                      "session" => uuid4(),
-                                      "msg_type" => "pyerr" ], content) :
+                                     "msg_type" => "pyerr"), content) :
                                  msg_pub(execute_msg, "pyerr", content)) 
                 end
             finally

--- a/src/comm_manager.jl
+++ b/src/comm_manager.jl
@@ -1,6 +1,7 @@
 module CommManager
 
 using IJulia
+using Compat
 
 import IJulia: Msg, uuid4, send_ipython, msg_pub
 
@@ -46,8 +47,8 @@ comm_target{target}(comm :: Comm{target}) = target
 function msg_comm(comm::Comm, m::IJulia.Msg, msg_type,
                   data=Dict{String,Any}(),
                   metadata=Dict{String, Any}(); kwargs...)
-    content = ["comm_id"=>comm.id,
-               "data"=>data]
+    content = @Compat.Dict("comm_id"=>comm.id,
+                           "data"=>data)
 
     for (k, v) in kwargs
         content[string(k)] = v
@@ -126,7 +127,7 @@ function comm_close(sock, msg)
         comm = comms[comm_id]
 
         if !haskey(msg.content, "data")
-            msg.content["data"] = {}
+            msg.content["data"] = @Compat.Dict()
         end
         comm.on_close(msg)
 

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -12,30 +12,30 @@ function complete_request(socket, msg)
     if sizeof(text) > length(positions)
         comps = [line[(cursorpos-sizeof(text)+1):(cursorpos-length(positions))]*s for s in comps]
     end
-    send_ipython(requests, msg_reply(msg, "complete_reply", [
+    send_ipython(requests, msg_reply(msg, "complete_reply", @Compat.Dict(
         "status" => "ok",
         "matches" => comps,
-        "matched_text" => line[positions],
-    ]))
+        "matched_text" => line[positions]
+    )))
 end
 
 function kernel_info_request(socket, msg)
     send_ipython(requests,
                  msg_reply(msg, "kernel_info_reply",
-                           ["protocol_version" => [4, 0],
+                           @Compat.Dict("protocol_version" => [4, 0],
                             "language_version" => [VERSION.major,
                                                    VERSION.minor,
                                                    VERSION.patch],
-                            "language" => "julia" ]))
+                            "language" => "julia")))
 end
 
 function connect_request(socket, msg)
     send_ipython(requests,
                  msg_reply(msg, "connect_reply",
-                           ["shell_port" => profile["shell_port"],
+                           @Compat.Dict("shell_port" => profile["shell_port"],
                             "iopub_port" => profile["iopub_port"],
                             "stdin_port" => profile["stdin_port"],
-                            "hb_port" => profile["hb_port"]]))
+                            "hb_port" => profile["hb_port"])))
 end
 
 function shutdown_request(socket, msg)
@@ -52,7 +52,7 @@ function object_info_request(socket, msg)
     try
         s = parse(msg.content["oname"])
         o = eval(Main, s)
-        content = ["oname" => msg.content["oname"],
+        content = @Compat.Dict("oname" => msg.content["oname"],
                    "found" => true,
                    "ismagic" => false,
                    "isalias" => false,
@@ -60,7 +60,7 @@ function object_info_request(socket, msg)
                    "type_name" => string(typeof(o)),
                    "base_class" => string(typeof(o).super),
                    "string_form" => get(msg.content,"detail_level",0) == 0 ? 
-                   sprint(16384, show, o) : repr(o) ]
+                   sprint(16384, show, o) : repr(o) )
         if method_exists(length, (typeof(o),))
             content["length"] = length(o)
         end
@@ -69,8 +69,8 @@ function object_info_request(socket, msg)
         @verror_show e catch_backtrace()
         send_ipython(requests,
                      msg_reply(msg, "object_info_reply",
-                               ["oname" => msg.content["oname"],
-                                "found" => false ]))
+                               @Compat.Dict("oname" => msg.content["oname"],
+                                "found" => false)))
     end
 end
 
@@ -79,11 +79,11 @@ function history_request(socket, msg)
     # as requested in ipython/ipython#3806
     send_ipython(requests,
                  msg_reply(msg, "history_reply",
-                           ["history" => []]))
+                           @Compat.Dict("history" => [])))
                              
 end
 
-const handlers = (String=>Function)[
+const handlers = Dict{String,Function}([
     "execute_request" => execute_request_0x535c5df2,
     "complete_request" => complete_request,
     "kernel_info_request" => kernel_info_request,
@@ -94,4 +94,4 @@ const handlers = (String=>Function)[
     "comm_open" => comm_open,
     "comm_msg" => comm_msg,
     "comm_close" => comm_close
-]
+])

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -18,9 +18,9 @@ for mime in ipy_mime
         function display(d::InlineDisplay, ::MIME{symbol($mime)}, x)
             send_ipython(publish, 
                          msg_pub(execute_msg, "display_data",
-                                 ["source" => "julia", # optional
+                                 @Compat.Dict("source" => "julia", # optional
                                   "metadata" => metadata(x), # optional
-                                  "data" => [$mime => stringmime(MIME($mime), x)] ]))
+                                  "data" => [$mime => stringmime(MIME($mime), x)])))
         end
     end
 end
@@ -34,9 +34,9 @@ function display(d::InlineDisplay, x)
     undisplay(x) # dequeue previous redisplay(x)
     send_ipython(publish, 
                  msg_pub(execute_msg, "display_data",
-                         ["source" => "julia", # optional
+                         @Compat.Dict("source" => "julia", # optional
                           "metadata" => metadata(x), # optional
-                          "data" => display_dict(x) ]))
+                          "data" => display_dict(x))))
 end
 
 # we overload redisplay(d, x) to add x to a queue of objects to display,

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -22,18 +22,18 @@ end
 # subscribers currently subscribe to all topics".]
 msg_pub(m::Msg, msg_type, content, metadata=Dict{String,Any}()) =
   Msg([ msg_type == "stream" ? content["name"] : msg_type ], 
-      ["msg_id" => uuid4(),
+      @Compat.Dict("msg_id" => uuid4(),
        "username" => m.header["username"],
        "session" => m.header["session"],
-       "msg_type" => msg_type],
+       "msg_type" => msg_type),
       content, m.header, metadata)
 
 msg_reply(m::Msg, msg_type, content, metadata=Dict{String,Any}()) =
   Msg(m.idents, 
-      ["msg_id" => uuid4(),
+      @Compat.Dict("msg_id" => uuid4(),
        "username" => m.header["username"],
        "session" => m.header["session"],
-       "msg_type" => msg_type],
+       "msg_type" => msg_type),
       content, m.header, metadata)
 
 function show(io::IO, msg::Msg)
@@ -88,20 +88,20 @@ function send_status(state::String, parent_header=nothing)
     if parent_header == nothing
         msg = Msg(
             [ "status" ],
-            [ "msg_id" => uuid4(),
+            @Compat.Dict("msg_id" => uuid4(),
              "username" => "jlkernel",
              "session" => execute_msg.header["session"],
-             "msg_type" => "status" ],
-            [ "execution_state" => state ]
+             "msg_type" => "status"),
+            @Compat.Dict("execution_state" => state)
         )
     else
         msg = Msg(
             [ "status" ],
-            [ "msg_id" => uuid4(),
+            @Compat.Dict("msg_id" => uuid4(),
              "username" => "jlkernel",
              "session" => execute_msg.header["session"],
-             "msg_type" => "status" ],
-            [ "execution_state" => state ],
+             "msg_type" => "status"),
+            @Compat.Dict("execution_state" => state),
             parent_header
         )
     end

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -23,7 +23,7 @@ function send_stream(s::String, name::String)
     if !isempty(s)
         send_ipython(publish,
                      msg_pub(execute_msg, "stream",
-                             ["name" => name, "data" => s]))
+                             @Compat.Dict("name" => name, "data" => s)))
     end
 end
 
@@ -63,7 +63,7 @@ function readline(io::Base.Pipe)
         end
         send_ipython(raw_input,
                      msg_reply(execute_msg, "input_request",
-                               ["prompt" => "STDIN> "]))
+                               @Compat.Dict("prompt" => "STDIN> ")))
         while true
             msg = recv_ipython(raw_input)
             if msg.header["msg_type"] == "input_reply"


### PR DESCRIPTION
Julia 0.4 changes the syntax for constructing Dicts; this commit
updates the package to use the new syntax. I think I've found all of
the places where it shows up and I get no deprecation warnings from
IJulia when I load it now.
