### PR TITLE
Prevent SIGINT from killing the kernel

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -12,7 +12,11 @@ include("inline.jl")
 using IPythonDisplay
 pushdisplay(InlineDisplay())
 
-ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
+if VERSION >= v"0.3"
+    ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
+else
+    ccall(:jl_install_sigint_handler, Void, ())
+end
 
 # the size of truncated output to show should not depend on the terminal
 # where the kernel is launched, since the display is elsewhere

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -12,7 +12,7 @@ include("inline.jl")
 using IPythonDisplay
 pushdisplay(InlineDisplay())
 
-ccall(:jl_install_sigint_handler, Void, ())
+ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
 
 # the size of truncated output to show should not depend on the terminal
 # where the kernel is launched, since the display is elsewhere


### PR DESCRIPTION
Clicking the Interrupt Kernel button is still causing the kernel to restart.  This PR implements the fix mentioned in #31 to match the change in how Julia handles interrupts (JuliaLang/julia@10c7d4e).