### PR TITLE
Better support for system-wise install

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -79,7 +79,9 @@ if VERSION >= v"0.3"
     push!(kernelcmd_array,"-i")
 end
 
-append!(kernelcmd_array, ["-F", escape_string(joinpath(Pkg.dir("IJulia"),"src","kernel.jl")), "{connection_file}"])
+# Can be used by packaging script to set correct system-wise install path
+ijulia_dir = get(ENV, "IJULIA_DIR", Pkg.dir("IJulia"))
+append!(kernelcmd_array, ["-F", escape_string(joinpath(ijulia_dir,"src","kernel.jl")), "{connection_file}"])
 
 
 


### PR DESCRIPTION
I've installed IJulia system-wise and the only difficulty was to install the "plugins" for IPython (Jupyter).

I've got everything working now and the only place I need to patch IJulia was the path to `kernel.jl` in `build.jl`. (copying the files without installing is also a little tricky but can be solved with existing env's)

Right now, I'm dealing with this by [checking a env](https://github.com/JuliaLang/IJulia.jl/commit/1154ec919b912e28d5f75c0dc8cdaf0b13a9abc8) I set in my packaging script so it should not break anything.

If this is not what you want (or at least not for now) I can just keep this patch as a fork since it simple enough.
