### PR TITLE
Remove space in kernel spec path

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,3 @@
-# TODO: Buld IPython 1.0 dependency? (wait for release?)
-
 #######################################################################
 import JSON
 using Compat
@@ -162,7 +160,7 @@ copy_config("julia.js", joinpath(juliaprof, "static", "components", "codemirror"
 #Is IJulia being built from a debug build? If so, add "debug" to the description
 debugdesc = ccall(:jl_is_debugbuild,Cint,())==1 ? " debug" : ""
 
-juliakspec = joinpath(chomp(readall(`$ipython locate`)), "kernels", "julia$(VERSION.major).$(VERSION.minor)"*debugdesc)
+juliakspec = joinpath(chomp(readall(`$ipython locate`)), "kernels", "julia-$(VERSION.major).$(VERSION.minor)"*debugdesc)
 
 
 ks = @compat Dict(

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -162,7 +162,7 @@ copy_config("julia.js", joinpath(juliaprof, "static", "components", "codemirror"
 #Is IJulia being built from a debug build? If so, add "debug" to the description
 debugdesc = ccall(:jl_is_debugbuild,Cint,())==1 ? " debug" : ""
 
-juliakspec = joinpath(chomp(readall(`$ipython locate`)), "kernels", "julia $(VERSION.major).$(VERSION.minor)"*debugdesc)
+juliakspec = joinpath(chomp(readall(`$ipython locate`)), "kernels", "julia$(VERSION.major).$(VERSION.minor)"*debugdesc)
 
 
 ks = @compat Dict(


### PR DESCRIPTION
On IPython 3.1, the space was causing problems with loading the logo (even though the kernel spec itself gets loaded).

```
[W 20:07:18.060 NotebookApp] 404 GET /kernelspecs/julia%200.3/logo-64x64.png
```

Perhaps this bug exists in IPython notebook itself for kernelspecs with a space in the name.