### PR TITLE
Update clear_history to use Range instead of Ranges

### DIFF
--- a/src/history.jl
+++ b/src/history.jl
@@ -26,7 +26,7 @@ function clear_history(indices)
 end
 
 # since a range could be huge, intersect it with 1:_n first
-clear_history{T<:Integer}(r::Ranges{T}) =
+clear_history{T<:Integer}(r::Range{T}) =
     invoke(clear_history, (Any,), intersect(r, 1:_n))
 
 function clear_history()


### PR DESCRIPTION
When loading IJulia, I received the following error:

```julia
julia> using IJulia
Warning: both Libdl and Base export "dlopen_e"; uses of it in module ZMQ must be qualified
ERROR: LoadError: LoadError: UndefVarError: Ranges not defined
 in include at ./boot.jl:250
 in include_from_node1 at ./loading.jl:129
 in include at ./boot.jl:250
 in include_from_node1 at ./loading.jl:129
 in reload_path at ./loading.jl:153
 in _require at ./loading.jl:68
 in require at ./loading.jl:51
while loading /home/brad/.julia/v0.4/IJulia/src/history.jl, in expression starting on line 29
while loading /home/brad/.julia/v0.4/IJulia/src/IJulia.jl, in expression starting on line 113
```

The warning is discussed in the comments in https://github.com/JuliaLang/julia/issues/11058

The error comes from a typo in history.jl, which hadn't mattered before, and for some reason started to matter recently.
