### PR TITLE
Updates to reflect julia 0.3 now being required

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ installer.  (Do *not* use Enthought Canopy/EPD.)
 
 * **Important**: on Windows, the Anaconda installer window gives options *Add Anaconda to the System Path* and also *Register Anaconda as default Python version of the system*.  Be sure to **check these boxes**.
 
-Second, [download Julia](http://julialang.org/downloads/) *version 0.2
+Second, [download Julia](http://julialang.org/downloads/) *version 0.3
 or later* and run the installer.  Then run the Julia application
 (double-click on it); a window with a `julia>` prompt will appear.  At
 the prompt, type:
@@ -120,9 +120,9 @@ the next few weeks or months.  Until then, you may have to
   you will need to install [PyQt4](http://www.riverbankcomputing.com/software/pyqt/download) or 
   [PySide](http://qt-project.org/wiki/Category:LanguageBindings::PySide).
 
-* You need Julia version 0.2 or later.
+* You need Julia version 0.3 or later.
 
-Once IPython 1.0+ and Julia 0.2+ are installed, you can install IJulia from a Julia console by typing:
+Once IPython 1.0+ and Julia 0.3+ are installed, you can install IJulia from a Julia console by typing:
 ```
 Pkg.add("IJulia")
 ```

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -67,17 +67,11 @@ c.$s = $val
 end
 
 # add Julia kernel manager if we don't have one yet
-if VERSION >= v"0.3-"
-    binary_name = @windows? "julia.exe":"julia"
-else
-    binary_name = @windows? "julia.bat":"julia-basic"
-end
+binary_name = @windows? "julia.exe":"julia"
 
 kernelcmd_array = [escape_string(joinpath(JULIA_HOME,("$binary_name")))]
 
-if VERSION >= v"0.3"
-    push!(kernelcmd_array,"-i")
-end
+push!(kernelcmd_array,"-i")
 
 # Can be used by packaging script to set correct system-wise install path
 ijulia_dir = get(ENV, "IJULIA_DIR", Pkg.dir("IJulia"))

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -12,11 +12,7 @@ include("inline.jl")
 using IPythonDisplay
 pushdisplay(InlineDisplay())
 
-if VERSION >= v"0.3"
-    ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
-else
-    ccall(:jl_install_sigint_handler, Void, ())
-end
+ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
 
 # the size of truncated output to show should not depend on the terminal
 # where the kernel is launched, since the display is elsewhere


### PR DESCRIPTION
As of 3de6248, julia 0.3 is required.  This pull request updates the README accordingly and removes old code for pre-0.3 versions.