### PR TITLE
use `jupyter kernelspec install` when available

### DIFF
--- a/deps/ipython.jl
+++ b/deps/ipython.jl
@@ -1,20 +1,24 @@
 # return (ipython, version) tuple, where ipython is the string of the
 # IPython executable, and version is the VersionNumber.
-function find_ipython()
+function find_kernelspec_cmd()
     try
-        "ipython",convert(VersionNumber, chomp(readall(`ipython --version`)))
+        "jupyter",convert(VersionNumber, chomp(readall(`jupyter kernelspec --version`)))
     catch e1
         try
-            "ipython2",convert(VersionNumber, chomp(readall(`ipython2 --version`)))
+            "ipython",convert(VersionNumber, chomp(readall(`ipython --version`)))
         catch e2
             try
-                "ipython3",convert(VersionNumber, chomp(readall(`ipython3 --version`)))
+                "ipython2",convert(VersionNumber, chomp(readall(`ipython2 --version`)))
             catch e3
                 try
-                    "ipython.bat",convert(VersionNumber, chomp(readall(`ipython.bat --version`)))
+                    "ipython3",convert(VersionNumber, chomp(readall(`ipython3 --version`)))
                 catch e4
-                    error("IPython is required for IJulia, got errors\n",
-                          "   $e1\n   $e2\n   $e3" * (@windows ? "\n$e4\n" : "") )
+                    try
+                        "ipython.bat",convert(VersionNumber, chomp(readall(`ipython.bat --version`)))
+                    catch e5
+                        error("Jupyter or IPython is required for IJulia, got errors\n",
+                              "   $e1\n   $e2\n   $e3\n   $e4" * (@windows ? "\n$e5\n" : "") )
+                    end
                 end
             end
         end


### PR DESCRIPTION
and use `ipython kernelspec install` for IPython 3, rather than attempting to reimplement the install process.

I didn't change the ipython2, ipython3 checks, but I'm not sure how one can get into a state where ipython2/3 exists but `ipython` does not.

closes #351