### PR TITLE
RFC: Numerous IO related fixes

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -133,6 +133,7 @@ include("handlers.jl")
 include("heartbeat.jl")
 
 function eventloop(socket)
+    task_local_storage(:IJulia_task, "write task")
     try
         while true
             msg = recv_ipython(socket)
@@ -147,7 +148,7 @@ function eventloop(socket)
                 if !isa(e, InterruptException)
                     content = error_content(e, msg="KERNEL EXCEPTION")
                     map(s -> println(orig_STDERR, s), content["traceback"])
-                    send_ipython(publish, 
+                    send_ipython(publish,
                                  execute_msg == nothing ?
                                  Msg([ "error" ],
                                      @compat(Dict("msg_id" => uuid4(),
@@ -156,7 +157,7 @@ function eventloop(socket)
                                                   "msg_type" => "error",
                                                   "version" => "5.0")),
                                      content) :
-                                 msg_pub(execute_msg, "error", content)) 
+                                 msg_pub(execute_msg, "error", content))
                 end
             finally
                 send_status("idle", msg.header)

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -21,7 +21,7 @@ end
 # of the spec yet" and is in practice currently ignored since "all
 # subscribers currently subscribe to all topics".]
 msg_pub(m::Msg, msg_type, content, metadata=Dict{AbstractString,Any}()) =
-  Msg([ msg_type == "stream" ? content["name"] : msg_type ], 
+  Msg([ msg_type == "stream" ? content["name"] : msg_type ],
       @compat(Dict("msg_id" => uuid4(),
                    "username" => m.header["username"],
                    "session" => m.header["session"],
@@ -30,7 +30,7 @@ msg_pub(m::Msg, msg_type, content, metadata=Dict{AbstractString,Any}()) =
       content, m.header, metadata)
 
 msg_reply(m::Msg, msg_type, content, metadata=Dict{AbstractString,Any}()) =
-  Msg(m.idents, 
+  Msg(m.idents,
       @compat(Dict("msg_id" => uuid4(),
                    "username" => m.header["username"],
                    "session" => m.header["session"],
@@ -41,7 +41,7 @@ msg_reply(m::Msg, msg_type, content, metadata=Dict{AbstractString,Any}()) =
 function show(io::IO, msg::Msg)
     print(io, "IPython Msg [ idents ")
     print_joined(io, msg.idents, ", ")
-    print(io, " ] {\n  header = $(msg.header),\n  metadata = $(msg.metadata),\n  content = $(msg.content)\n}")
+    print(io, " ] {\n  parent_header = $(msg.parent_header),\n  header = $(msg.header),\n  metadata = $(msg.metadata),\n  content = $(msg.content)\n}")
 end
 
 function send_ipython(socket, m::Msg)


### PR DESCRIPTION
- Fixes #372 by removing the `sleep(0.1)` in watch_stream (that was there to slow the rate of messages sent) and instead continually reading the `read_stdout` and `read_stderr` streams (whose buffers are limited to 64KB on OSX/Linux, 4KB Windows?) and adding data read into our own `IOBuffer`s (which are essentially limited only by memory size AFAIK)
    - The rate of sending is controlled by a `stream_interval` parameter; a stream message is sent at most once every `stream_interval` seconds (currently 0.1). The exception to this is if the buffer has reached the size specified in `max_size` (currently 10KB), and will then be sent immediately. This is to avoid overly large stream messages being sent. This mechanism also fixes #342.
- Fixes #238 #347
    - the ideas outlined here (https://github.com/JuliaLang/IJulia.jl/issues/347#issuecomment-144505862 and https://github.com/JuliaLang/IJulia.jl/issues/347#issuecomment-144605024) were implemented (see oslibuv_flush() in stdio.jl):
        - many thanks to @vtjnash for those suggestions
        - n.b. without the changes outlined above, these don't work, chiefly due to the `sleep(0.1)` in the existing watch stream implementation.
- Also fixes using `?keyword` (e.g. `?try`)
- Added timestamps to the debug logging and the task which the `vprintln` call is made from
- Notes:
    - Needs testing on Windows (and Linux for that matter, I'm on OSX)
    - Apologies for the occasional weird whitespace changes at the end of lines my editor is adding, not sure what's going on there. (n.b: you can add `?w=1` to any diff url on github to disable whitespace only changes)
    - We should discuss how we might add tests to the package