### PR TITLE
0.5 deprecations: super -> supertype and readbytes -> read

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.3
 Nettle 0.2
 JSON 0.5
 ZMQ 0.3
-Compat 0.7
+Compat 0.7.9
 Conda 0.1.5

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -45,7 +45,7 @@ function watch_stream(rd::IO, name::AbstractString)
         while !eof(rd) # blocks until something is available
             nb = nb_available(rd)
             if nb > 0
-                write(buf, readbytes(rd, nb))
+                write(buf, read(rd, nb))
             end
             if buf.size > 0
                 if buf.size >= max_bytes
@@ -151,7 +151,7 @@ function readline(io::StdioPipe)
             end
         end
     else
-        invoke(readline, (super(StdioPipe),), io)
+        invoke(readline, (supertype(StdioPipe),), io)
     end
 end
 
@@ -183,7 +183,7 @@ end
 
 import Base.flush
 function flush(io::StdioPipe)
-    invoke(flush, (super(StdioPipe),), io)
+    invoke(flush, (supertype(StdioPipe),), io)
     if io == STDOUT
         oslibuv_flush()
         send_stream("stdout")


### PR DESCRIPTION
IMPORTANT NOTE: This PR should not be merged until a new version of Compat (currently v0.7.8) is tagged/published.

Just getting a jump on a few upcoming deprecations for Julia v0.5. I've checked that these changes seem to work on both release-0.4 and master; I guess a more robust testing framework is tricky for this sort of package.