### PR TITLE
catch_backtrace must be called early after catch

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -71,8 +71,7 @@ else
 end
 
 # return the content of a pyerr message for exception e
-function error_content(e; backtrace_top::Symbol=:execute_request_0x535c5df2, msg::AbstractString="")
-    bt = catch_backtrace()
+function error_content(e, bt; backtrace_top::Symbol=:execute_request_0x535c5df2, msg::AbstractString="")
     tb = map(utf8, @compat(split(sprint(show_bt,
                                         backtrace_top,
                                         bt, 1:typemax(Int)),
@@ -224,6 +223,7 @@ function execute_request_0x535c5df2(socket, msg)
                                             "execution_count" => _n,
                                             "user_expressions" => user_expressions)))
     catch e
+        bt = catch_backtrace()
         try
             # flush pending stdio
             flush_all()
@@ -233,7 +233,7 @@ function execute_request_0x535c5df2(socket, msg)
         catch
         end
         empty!(displayqueue) # discard pending display requests on an error
-        content = error_content(e)
+        content = error_content(e,bt)
         send_ipython(publish, msg_pub(msg, "error", content))
         content["status"] = "error"
         content["execution_count"] = _n


### PR DESCRIPTION
The state fetched by `catch_backtrace` might get erased if IO operations occur in the same catch block before `catch_backtrace` is called.

(this is a workaround to https://github.com/JuliaLang/julia/issues/13947)

Test case (a less complex call to `println` doesn't show the same problem):
```
println(" ", 1, " ", Dates.Date(2016,1,1))
collect(Int64,[1.5])
```
on x86_64-apple-darwin15.4.0 from homebrew Version 0.4.5 (2016-03-18 00:58 UTC) this produces
    
```
 1 2016-01-01
LoadError: InexactError()
while loading In[1], in expression starting on line 2
 
 
```

after this PR the output contains the backtrace as intended:
    
```
 1 2016-01-01
LoadError: InexactError()
while loading In[1], in expression starting on line 2
 
 in collect at array.jl:256
 
```