### PR TITLE
Additional workarounds for jupyter-kernelspec.exe

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -123,16 +123,26 @@ catch
             end
             python = abspath(Conda.PYTHONDIR, "python.exe")
         else
-            jk_path = readchomp(`where.exe $jupyter-kernelspec`)
-            jn_path = readchomp(`where.exe $jupyter-notebook`)
-            # jupyter-kernelspec should start with "#!/path/to/python":
-            python = strip(chomp(open(readline, jk_path, "r"))[3:end])
-            # strip quotes, if any
-            if python[1] == python[end] == '"'
-                python = python[2:end-1]
+            jupyter_dir = splitdir(jupyter)[1]
+            jks_exe = joinpath(jupyter_dir, "jupyter-kernelspec.exe")
+            if !isfile(jks_exe)
+                jk_path = readchomp(`where.exe $jupyter-kernelspec`)
+                jn_path = readchomp(`where.exe $jupyter-notebook`)
+                # jupyter-kernelspec should start with "#!/path/to/python":
+                python = strip(chomp(open(readline, jk_path, "r"))[3:end])
+                # strip quotes, if any
+                if python[1] == python[end] == '"'
+                    python = python[2:end-1]
+                end
+            else
+                jn_path = joinpath(jupyter_dir, "jupyter-notebook.exe")
             end
         end
-        run(`$python $jk_path install --replace --user $juliakspec`)
+        if isfile(jks_exe)
+            run(`$jks_exe install --replace --user $juliakspec`)
+        else
+            run(`$python $jk_path install --replace --user $juliakspec`)
+        end
         if endswith(jn_path, ".exe")
             push!(notebook, jn_path)
         else

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -112,7 +112,8 @@ catch
 
     # issue #363:
     @windows_only begin
-        if dirname(jupyter) == abspath(Conda.SCRIPTDIR)
+        jupyter_dir = dirname(jupyter)
+        if jupyter_dir == abspath(Conda.SCRIPTDIR)
             jk_path = "$jupyter-kernelspec"
             if isfile(jk_path * "-script.py")
                 jk_path *= "-script.py"
@@ -123,7 +124,6 @@ catch
             end
             python = abspath(Conda.PYTHONDIR, "python.exe")
         else
-            jupyter_dir = splitdir(jupyter)[1]
             jks_exe = joinpath(jupyter_dir, "jupyter-kernelspec.exe")
             if !isfile(jks_exe)
                 jk_path = readchomp(`where.exe $jupyter-kernelspec`)
@@ -134,7 +134,7 @@ catch
                 if python[1] == python[end] == '"'
                     python = python[2:end-1]
                 end
-            else
+            elseif isfile(jn_path) || error("$jn_path not found")
                 jn_path = joinpath(jupyter_dir, "jupyter-notebook.exe")
             end
         end

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -134,8 +134,9 @@ catch
                 if python[1] == python[end] == '"'
                     python = python[2:end-1]
                 end
-            elseif isfile(jn_path) || error("$jn_path not found")
+            else 
                 jn_path = joinpath(jupyter_dir, "jupyter-notebook.exe")
+                isfile(jn_path) || error("$jn_path not found")
             end
         end
         if isfile(jks_exe)


### PR DESCRIPTION
This proposed change amends and extends the previously included (so-called) hacks for Windows that were added for issue #363 (that are waiting on issue #448 for the jupyter project).  These changes allow for IJulia to work with a version of Python that has been downloaded from python.org, where jupyter was pip installed with a version recent enough to include jupyter-kernelspec.exe and jupyter-notebook.exe, and where the end user has set the JUPYTER environment variable either at the system level or in ENV within their Julia session prior to building IJulia via Pkg.build.

If the issues that led to the discussion in #363 and jupyter issue #448 have been addressed, then the changes in this commit and PR can likely be ignored.