### PR TITLE
Fix UndefVarError: jks_exe while building IJulia

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -114,6 +114,7 @@ catch
     # issue #363:
     @windows_only begin
         jupyter_dir = dirname(jupyter)
+        jks_exe = ""
         if jupyter_dir == abspath(Conda.SCRIPTDIR)
             jk_path = "$jupyter-kernelspec"
             if isfile(jk_path * "-script.py")


### PR DESCRIPTION
This fixes this error 
```
julia> Pkg.build("IJulia")
..........
INFO: Found Jupyter version 4.0.6: C:\Users\Hoegh\.julia\v0.4\Conda\deps\usr\Scripts\jupyter
Writing IJulia kernelspec to C:\Users\Hoegh\.julia\v0.4\IJulia\deps\julia-0.4\kernel.json ...
Installing julia kernelspec julia-0.4
jupyter: 'kernelspec' is not a Jupyter command
===============================[ ERROR: IJulia ]================================

LoadError: UndefVarError: jks_exe not defined
while loading C:\Users\Hoegh\.julia\v0.4\IJulia\deps\build.jl, in expression starting on line 143

================================================================================

=========================================================[ BUILD ERRORS ]=======================================================


WARNING: IJulia had build errors.

 - packages with build errors remain installed in C:\Users\Hoegh\.julia\v0.4
 - build the package(s) and all dependencies with `Pkg.build("IJulia")`
 - build a single package by running its `deps/build.jl` script

================================================================================================================================
```

This happens when my Conda.jl is used. I would appreciate if a new version could be tagged with the fix.
