### PR TITLE
Fix use of `invoke`

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -187,7 +187,7 @@ end
 
 # since a range could be huge, intersect it with 1:n first
 clear_history{T<:Integer}(r::Range{T}) =
-    invoke(clear_history, (Any,), intersect(r, 1:n))
+    invoke(clear_history, Tuple{Any}, intersect(r, 1:n))
 
 function clear_history()
     empty!(In)

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -176,10 +176,9 @@ function execute_request(socket, msg)
         undisplay(result) # dequeue if needed, since we display result in pyout
         display() # flush pending display requests
 
-        if result != nothing
+        if result !== nothing
             # Work around for Julia issue #265 (see # #7884 for context)
-            # We have to explicitly invoke the correct metadata method.
-            result_metadata = invoke(metadata, (typeof(result),), result)
+            result_metadata = eval(:(metadata($(QuoteNode(result)))))
             send_ipython(publish[],
                          msg_pub(msg, "execute_result",
                                  Dict("execution_count" => n,

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -147,7 +147,7 @@ function readline(io::StdioPipe)
             end
         end
     else
-        invoke(readline, (supertype(StdioPipe),), io)
+        invoke(readline, Tuple{supertype(StdioPipe)}, io)
     end
 end
 
@@ -181,7 +181,7 @@ end
 
 import Base.flush
 function flush(io::StdioPipe)
-    invoke(flush, (supertype(StdioPipe),), io)
+    invoke(flush, Tuple{supertype(StdioPipe)}, io)
     if io == STDOUT
         oslibuv_flush()
         send_stream("stdout")


### PR DESCRIPTION
* Use tuple type instead of tuples (Ref https://github.com/JuliaLang/julia/pull/18444 and it's easier to infer in general)
* Use `eval` instead of `invoke` to see newly defined methods. The old method won't work after https://github.com/JuliaLang/julia/pull/18444 or after JuliaLang/julia#265 is fixed.