### PR TITLE
truncate excess output per execution request

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,3 +250,13 @@ your `.julia` package directory) to change the line `verbose = false`
 at the top to `verbose = true` and `const capture_stderr = true` to
 `const capture_stderr = false`.  Then restart the kernel or open a new
 notebook and look for the error message when IJulia dies.
+
+### Preventing truncation of output
+
+The new default behavior of IJulia is to truncate stdout (via `show` or `println`)
+after 512kb. This to prevent browsers from getting bogged down when displaying the
+results. This limit can be increased to a custom value, like 1MB, as follows
+
+```
+IJulia.set_max_excessive_output(1 << 20)
+```

--- a/README.md
+++ b/README.md
@@ -258,5 +258,5 @@ after 512kb. This to prevent browsers from getting bogged down when displaying t
 results. This limit can be increased to a custom value, like 1MB, as follows
 
 ```
-IJulia.set_max_excessive_output(1 << 20)
+IJulia.set_max_stdio(1 << 20)
 ```

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -286,15 +286,14 @@ end
 
 
 """
-    set_max_excessive_output(max_output::Int)
+    set_max_stdio(max_output::Integer)
 
-Sets the maximum number of bytes, `max_output`, that can be written to stdout
-before getting truncated. A large value here allows a lot of output to be
+Sets the maximum number of bytes, `max_output`, that can be written to stdout and
+stderr before getting truncated. A large value here allows a lot of output to be
 displayed in the notebook, potentially bogging down the browser.
 """
-function set_max_excessive_output(max_output::Int)
+function set_max_stdio(max_output::Integer)
     max_output_per_request[] = max_output
-    println("Stdout will now be truncated after $max_output bytes")
 end
 
 

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -284,6 +284,20 @@ function clear_output(wait=false)
                                     Dict("wait" => wait)))
 end
 
+
+"""
+    set_max_excessive_output(max_output::Int)
+
+Sets the maximum number of bytes, `max_output`, that can be written to stdout
+before getting truncated. A large value here allows a lot of output to be
+displayed in the notebook, potentially bogging down the browser.
+"""
+function set_max_excessive_output(max_output::Int)
+    max_output_per_request[] = max_output
+    println("Stdout will now be truncated after $max_output bytes")
+end
+
+
 #######################################################################
 
 include("init.jl")

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -111,6 +111,9 @@ end
 
 # global variable so that display can be done in the correct Msg context
 execute_msg = Msg(["julia"], Dict("username"=>"julia", "session"=>"????"), Dict())
+# global variable tracking the number of bytes written in the current execution
+# request
+const stdout_bytes = Ref(0)
 
 function helpcode(code::AbstractString)
     code_ = strip(code)
@@ -132,6 +135,7 @@ function execute_request(socket, msg)
     @vprintln("EXECUTING ", code)
     global execute_msg = msg
     global n, In, Out, ans
+    stdout_bytes[] = 0
     silent = msg.content["silent"]
     store_history = get(msg.content, "store_history", !silent)
     empty!(execute_payloads)

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -113,7 +113,7 @@ end
 execute_msg = Msg(["julia"], Dict("username"=>"julia", "session"=>"????"), Dict())
 # global variable tracking the number of bytes written in the current execution
 # request
-const stdout_bytes = Ref(0)
+const stdio_bytes = Ref(0)
 
 function helpcode(code::AbstractString)
     code_ = strip(code)
@@ -135,7 +135,7 @@ function execute_request(socket, msg)
     @vprintln("EXECUTING ", code)
     global execute_msg = msg
     global n, In, Out, ans
-    stdout_bytes[] = 0
+    stdio_bytes[] = 0
     silent = msg.content["silent"]
     store_history = get(msg.content, "store_history", !silent)
     empty!(execute_payloads)


### PR DESCRIPTION
fixes https://github.com/timholy/Images.jl/issues/558, fixes #455