### PR TITLE
Enable setting the header message under which stream messages are sent

### DIFF
--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -91,6 +91,20 @@ end
 send_stdout(t::Timer) = send_stdio("stdout")
 send_stderr(t::Timer) = send_stdio("stderr")
 
+"""
+Jupyter associates cells with message headers. Once a cell's execution state has
+been set as to idle, it will silently drop stream messages (i.e. output to
+stdout and stderr) - see https://github.com/jupyter/notebook/issues/518.
+When using Interact, and a widget's state changes, a new
+message header is sent to the IJulia kernel, and while Reactive
+is updating Signal graph state, it's execution state is busy, meaning Jupyter
+will not drop stream messages if Interact can set the header message under which
+the stream messages will be sent. Hence the need for this function.
+"""
+function set_cur_msg(msg)
+    global execute_msg = msg
+end
+
 function send_stream(name::AbstractString)
     buf = bufs[name]
     if buf.size > 0


### PR DESCRIPTION
It seems that the only reason Interact.jl [can't display/print within `@manipulate`/`map`](https://github.com/JuliaLang/Interact.jl/issues/41) in IJulia, is just that IJulia is not sending the "correct" message header on stream messages resulting from Interact updates, and output/stream messages are being silently dropped by the front-end. This PR enables Interact to set the message header on stream messages, enabling the fix in [this Interact.jl PR](https://github.com/JuliaLang/Interact.jl/pull/119).

More detail in the docstring in the code.