### PR TITLE
Add a flush_all to the end of the eventloop

### DIFF
--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -26,6 +26,7 @@ function eventloop(socket)
                                  msg_pub(execute_msg, "error", content))
                 end
             finally
+                flush_all()
                 send_status("idle", msg.header)
             end
         end


### PR DESCRIPTION
Some Interact/Reactive stuff is async now, and I think putting that flush can help slightly with lost output, particularly on errors, for example during user widget interaction.