### PR TITLE
Add mechanism to delay sending the idle message.

### DIFF
--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -26,7 +26,11 @@ function eventloop(socket)
                                  msg_pub(execute_msg, "error", content))
                 end
             finally
-                send_status("idle", msg.header)
+                @async begin
+                    sleep(idle_delay[])
+                    flush_all()
+                    send_status("idle", msg.header)
+                end
             end
         end
     catch e
@@ -55,4 +59,9 @@ function waitloop()
             end
         end
     end
+end
+
+const idle_delay = Ref(0.5)
+function set_idle_delay(delay_secs::Float64=0.5)
+    idle_delay[] = delay_secs
 end


### PR DESCRIPTION
Jupyter removes IO handling callbacks associated with a cell when the `"status":"idle"` message with the (parent header's) `msg_id` associated with the cell is received. New (asynchronous) output stream messages received after the `"status":"idle"` will still be routed to the last active cell under normal circumstances. However, if a new message is sent by the front-end, the `last_msg_callbacks` that would have put the output on an appropriate cell are overwritten/cleared and subsequent stream messages are silently dropped.

This change will allow other packages to tell IJulia to delay sending the `status:idle`. In particular, it will help when Interact.jl displays a signal but also has an error during an asynchronous `push!` to that or another signal. In that case Interact's javascript sends a comm_msg which clears the  `last_msg_callbacks` as described above, and the error message/stacktrace is usually truncated. With this change, Interact can tell IJulia to delay sending the idle by, e.g., 0.5 secs which fixes the problem.