### PR TITLE
print_history() function

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -212,7 +212,7 @@ clear_history
 
 #######################################################################
 # methods to print history or any subset thereof
-function print_history(io::IO, indices)
+function history(io::IO, indices)
 	# since a range could be huge, intersect it with 1:n first
     for n in intersect(indices, 1:IJulia.n)
       if haskey(In, n)
@@ -220,16 +220,16 @@ function print_history(io::IO, indices)
       end
     end
 end
-print_history(x) = print_history(Base.STDOUT, x)
-print_history() = print_history(1:n)
+history(x) = history(Base.STDOUT, x)
+history() = history(1:n)
 
 # print the last x history entries when argument x is integer
-print_history(io::IO, x::Integer) =
-    invoke(print_history, Tuple{IO, Any}, io, n-x:n)
+history(io::IO, x::Integer) =
+    invoke(history, Tuple{IO, Any}, io, n-x:n)
 """
-    print_history([io], [indices])
+    history([io], [indices])
 
-The `print_history()` function prints all of the input history stored in
+The `history()` function prints all of the input history stored in
 the running IJulia notebook in a format convenient for copying.
 
 The optional `indices` argument is a collection of indices indicating
@@ -238,7 +238,7 @@ a subset of cell inputs to print.
 The optional `io` argument is for specifying an output stream. The default
 is Base.STDOUT.
 """
-print_history
+history
 
 #######################################################################
 # Similar to the ipython kernel, we provide a mechanism by

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -212,20 +212,18 @@ clear_history
 
 #######################################################################
 # methods to print history or any subset thereof
-function history(io::IO, indices)
-	# since a range could be huge, intersect it with 1:n first
+function history(io::IO, indices::AbstractVector{Int})
     for n in intersect(indices, 1:IJulia.n)
       if haskey(In, n)
         print(In[n])
       end
     end
 end
-history(x) = history(Base.STDOUT, x)
-history() = history(1:n)
 
-# print the last x history entries when argument x is integer
-history(io::IO, x::Integer) =
-    invoke(history, Tuple{IO, Any}, io, n-x:n)
+history(io::IO, x::Union{Integer,AbstractVector{Int}}...) = history(io, vcat(x...))
+history(x...) = history(STDOUT, x...)
+history(io::IO, x...) = throw(MethodError(history, (x...)))
+history() = history(1:n)
 """
     history([io], [indices])
 

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -225,13 +225,13 @@ history(x...) = history(STDOUT, x...)
 history(io::IO, x...) = throw(MethodError(history, (x...)))
 history() = history(1:n)
 """
-    history([io], [indices])
+    history([io], [indices...])
 
 The `history()` function prints all of the input history stored in
 the running IJulia notebook in a format convenient for copying.
 
-The optional `indices` argument is a collection of indices indicating
-a subset of cell inputs to print.
+The optional `indices` argument is one or more indices or collections
+of indices indicating a subset input cells to print.
 
 The optional `io` argument is for specifying an output stream. The default
 is Base.STDOUT.

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -234,7 +234,7 @@ The optional `indices` argument is one or more indices or collections
 of indices indicating a subset input cells to print.
 
 The optional `io` argument is for specifying an output stream. The default
-is Base.STDOUT.
+is `STDOUT`.
 """
 history
 

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -223,16 +223,28 @@ end
 # since a range could be huge, intersect it with 1:n first
 print_history{T<:Integer}(io::IO=Base.STDOUT, r::Range{T}=1:n) =
     invoke(print_history, Tuple{IO, Any}, io, intersect(r, 1:n))
-
 print_history{T<:Integer}(r::Range{T}) =
-    invoke(print_history, Tuple{IO, Any}, Base.STDOUT, intersect(r, 1:n))
+    print_history(Base.STDOUT, r)
 
+print_history(io::IO, x::Integer) =
+    invoke(print_history, Tuple{IO, Any}, io, n-x:n)
+print_history(x::Integer) =
+    print_history(Base.STDOUT, x)
+
+print_history{T<:Integer}(io::IO, a::Array{T, 1}) =
+    invoke(print_history, Tuple{IO, Any}, io, intersect(a, 1:n))
+print_history{T<:Integer}(a::Array{T, 1}) =
+    print_history(Base.STDOUT, a)
+
+print_history{T<:Integer}(io::IO, t::Tuple{Vararg{T}}) =
+    invoke(print_history, Tuple{IO, Any}, io, intersect(t, 1:n))
+print_history{T<:Integer}(t::Tuple{Vararg{T}}) =
+    print_history(Base.STDOUT, t)
 """
     print_history([io], [indices])
 
 The `print_history()` function prints all of the input history stored in
-the running IJulia notebook, with most recent last. The Input history is
-printed without cell numbers so it can be directly pasted into an editor.
+the running IJulia notebook in a format convenient for copying.
 
 The optional `indices` argument is a collection of indices indicating
 a subset of cell inputs to print.

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -211,6 +211,38 @@ a subset of cell inputs/outputs to clear.
 clear_history
 
 #######################################################################
+# methods to print history or any subset thereof
+function print_history(io::IO, indices)
+    for n in indices
+      if haskey(In, n)
+        print(In[n])
+      end
+    end
+end
+
+# since a range could be huge, intersect it with 1:n first
+print_history{T<:Integer}(io::IO=Base.STDOUT, r::Range{T}=1:n) =
+    invoke(print_history, Tuple{IO, Any}, io, intersect(r, 1:n))
+
+print_history{T<:Integer}(r::Range{T}) =
+    invoke(print_history, Tuple{IO, Any}, Base.STDOUT, intersect(r, 1:n))
+
+"""
+    print_history([io], [indices])
+
+The `print_history()` function prints all of the input history stored in
+the running IJulia notebook, with most recent last. The Input history is
+printed without cell numbers so it can be directly pasted into an editor.
+
+The optional `indices` argument is a collection of indices indicating
+a subset of cell inputs to print.
+
+The optional `io` argument is for specifying an output stream. The default
+is Base.STDOUT.
+"""
+print_history
+
+#######################################################################
 # Similar to the ipython kernel, we provide a mechanism by
 # which modules can register thunk functions to be called after
 # executing an input cell, e.g. to "close" the current plot in Pylab.

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -213,33 +213,19 @@ clear_history
 #######################################################################
 # methods to print history or any subset thereof
 function print_history(io::IO, indices)
-    for n in indices
+	# since a range could be huge, intersect it with 1:n first
+    for n in intersect(indices, 1:IJulia.n)
       if haskey(In, n)
         print(In[n])
       end
     end
 end
+print_history(x) = print_history(Base.STDOUT, x)
+print_history() = print_history(1:n)
 
-# since a range could be huge, intersect it with 1:n first
-print_history{T<:Integer}(io::IO=Base.STDOUT, r::Range{T}=1:n) =
-    invoke(print_history, Tuple{IO, Any}, io, intersect(r, 1:n))
-print_history{T<:Integer}(r::Range{T}) =
-    print_history(Base.STDOUT, r)
-
+# print the last x history entries when argument x is integer
 print_history(io::IO, x::Integer) =
     invoke(print_history, Tuple{IO, Any}, io, n-x:n)
-print_history(x::Integer) =
-    print_history(Base.STDOUT, x)
-
-print_history{T<:Integer}(io::IO, a::Array{T, 1}) =
-    invoke(print_history, Tuple{IO, Any}, io, intersect(a, 1:n))
-print_history{T<:Integer}(a::Array{T, 1}) =
-    print_history(Base.STDOUT, a)
-
-print_history{T<:Integer}(io::IO, t::Tuple{Vararg{T}}) =
-    invoke(print_history, Tuple{IO, Any}, io, intersect(t, 1:n))
-print_history{T<:Integer}(t::Tuple{Vararg{T}}) =
-    print_history(Base.STDOUT, t)
 """
     print_history([io], [indices])
 

--- a/src/magics.jl
+++ b/src/magics.jl
@@ -121,11 +121,11 @@ gui_magic_help(magic::AbstractString, args::AbstractString) = md"""
     provide their own event-loop integration."""
 
 history_magic_help(magic::AbstractString, args::AbstractString) = md"""
-    The analogue of the `%history` magic of IPython, which provides
-    access to the input history, is to access the global variable `In`
-    in IJulia.  `In` is a dictionary mapping cell numbers to the inputs.
-    However, IJulia does not currently keep any other history, e.g.
-    it discards input cells that you overwrite.
+    An analogue of the `%history` magic of IPython, which provides
+    access to the input history, is given by IJulia.print_history(). It is
+    based on the global variable `In` in IJulia. `In` is a dictionary
+    mapping cell numbers to the inputs. However, IJulia does not currently
+    keep any other history, e.g. it discards input cells that you overwrite.
 """
 
 load_magic_help(magic::AbstractString, args::AbstractString) = md"""

--- a/src/magics.jl
+++ b/src/magics.jl
@@ -122,7 +122,7 @@ gui_magic_help(magic::AbstractString, args::AbstractString) = md"""
 
 history_magic_help(magic::AbstractString, args::AbstractString) = md"""
     An analogue of the `%history` magic of IPython, which provides
-    access to the input history, is given by IJulia.print_history(). It is
+    access to the input history, is given by IJulia.history(). It is
     based on the global variable `In` in IJulia. `In` is a dictionary
     mapping cell numbers to the inputs. However, IJulia does not currently
     keep any other history, e.g. it discards input cells that you overwrite.

--- a/src/magics.jl
+++ b/src/magics.jl
@@ -121,7 +121,7 @@ gui_magic_help(magic::AbstractString, args::AbstractString) = md"""
     provide their own event-loop integration."""
 
 history_magic_help(magic::AbstractString, args::AbstractString) = md"""
-    An analogue of the `%history` magic of IPython, which provides
+    An analogue of the `%history` or `%hist` magic of IPython, which provides
     access to the input history, is given by IJulia.history(). It is
     based on the global variable `In` in IJulia. `In` is a dictionary
     mapping cell numbers to the inputs. However, IJulia does not currently
@@ -400,6 +400,7 @@ const magic_help = Dict{Compat.ASCIIString, Function}(
     "%edit" => edit_magic_help,
     "%env" => env_magic_help,
     "%gui" => gui_magic_help,
+    "%hist" => history_magic_help,
     "%history" => history_magic_help,
     "%load" => load_magic_help,
     "%loadpy" => load_magic_help,


### PR DESCRIPTION
As discussed in #497, this adds a print_history function to IJulia that prints the input history similar to IPythons %history magic. Arguments can be an ::IO target and an integer range, array, or tuple to specify the cell number to output. The default print_history() prints all input history.