### PR TITLE
pre/post execute hooks fail due to world age

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -149,7 +149,7 @@ function execute_request(socket, msg)
 
     try
         for hook in preexecute_hooks
-            hook()
+            @eval $hook()
         end
 
         #run the code!
@@ -172,7 +172,7 @@ function execute_request(socket, msg)
         end
 
         for hook in postexecute_hooks
-            hook()
+            @eval $hook()
         end
 
         # flush pending stdio
@@ -205,7 +205,7 @@ function execute_request(socket, msg)
             # flush pending stdio
             flush_all()
             for hook in posterror_hooks
-                hook()
+                @eval $hook()
             end
         catch
         end


### PR DESCRIPTION
When trying to use PyPlot with IJulia notebook, I get the following error (after fixing https://github.com/JuliaLang/IJulia.jl/issues/504):

```
MethodError: no method matching display_figs()
The applicable method may be too new: running in world age 21524, while current world is 21536.
Closest candidates are:
  display_figs() at /home/adam/.julia/v0.6/PyPlot/src/PyPlot.jl:110 (method too new to be called from this world context.)

Stacktrace:
 [1] execute_request(::ZMQ.Socket, ::IJulia.Msg) at /home/adam/.julia/v0.6/IJulia/src/execute_request.jl:175
 [2] eventloop(::ZMQ.Socket) at /home/adam/.julia/v0.6/IJulia/src/eventloop.jl:8
 [3] (::IJulia.##9#12)() at ./task.jl:335
```

I'm not totally clear how the new world age stuff is supposed to work, but this three line patch gets IJulia + PyPlot back to working on today's master.