### PR TITLE
Fix comparision with nothing

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -158,7 +158,7 @@ function execute_request(socket, msg)
 
         if silent
             result = nothing
-        elseif result != nothing
+        elseif result !== nothing
             if store_history
                 if result != Out # workaround for Julia #3066
                     Out[n] = result


### PR DESCRIPTION
Because of this comparison, if `result` implements the comparision between itself and `Any` it needs to add a special case with `nothing`. See e.g. https://github.com/blegat/MultivariatePolynomials.jl/issues/22
This is fixed by this PR
cc @rdeits