### PR TITLE
Call message handlers with invokelatest on 0.6-rc1+

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.5
 MbedTLS 0.4.3
 JSON 0.5
 ZMQ 0.3.3
-Compat 0.9.5
+Compat 0.25.1
 Conda 0.1.5

--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -1,3 +1,5 @@
+import Compat.invokelatest # for callbacks
+
 function eventloop(socket)
     task_local_storage(:IJulia_task, "write task")
     try
@@ -5,7 +7,7 @@ function eventloop(socket)
             msg = recv_ipython(socket)
             try
                 send_status("busy", msg.header)
-                handlers[msg.header["msg_type"]](socket, msg)
+                invokelatest(handlers[msg.header["msg_type"]], socket, msg)
             catch e
                 # Try to keep going if we get an exception, but
                 # send the exception traceback to the front-ends.


### PR DESCRIPTION
This is needed for Interact to work on 0.6

- [x] Fix REQUIRE for Compat after https://github.com/JuliaLang/Compat.jl/pull/359 is merged