### PR TITLE
Allows self referential result history

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -164,9 +164,7 @@ function execute_request(socket, msg)
             result = nothing
         elseif result !== nothing
             if store_history
-                if result != Out # workaround for Julia #3066
-                    Out[n] = result
-                end
+                Out[n] = result
             end
         end
 


### PR DESCRIPTION
Julia 3066 is long resolved: https://github.com/JuliaLang/julia/issues/3066#issuecomment-45560974
Without this change `result != Out` is run on all results and `!=` may not be defined, and/or cause errors - e.g. these two cells on a fresh notebook
```
1
```
Out[1]: 1
```
using TensorFlow
x = placeholder(Float32)
```
Cause an error.