### PR TITLE
Fix findfirst depreciation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.5
 MbedTLS 0.4.3
 JSON 0.5
 ZMQ 0.3.3
-Compat 0.27.0
+Compat 0.33.0
 Conda 0.1.5

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -264,7 +264,7 @@ push_postexecute_hook(f::Function) = push!(postexecute_hooks, f)
 Remove a function `f()` from the list of functions to
 execute after executing any notebook cell.
 """
-pop_postexecute_hook(f::Function) = splice!(postexecute_hooks, findfirst(x -> x == postexecute_hooks, f))
+pop_postexecute_hook(f::Function) = @compat splice!(postexecute_hooks, findfirst(equalto(f), postexecute_hooks))
 
 const preexecute_hooks = Function[]
 """
@@ -280,7 +280,7 @@ push_preexecute_hook(f::Function) = push!(preexecute_hooks, f)
 Remove a function `f()` from the list of functions to
 execute before executing any notebook cell.
 """
-pop_preexecute_hook(f::Function) = splice!(preexecute_hooks, findfirst(x -> x == preexecute_hooks, f))
+pop_preexecute_hook(f::Function) = @compat splice!(preexecute_hooks, findfirst(equalto(f), preexecute_hooks))
 
 # similar, but called after an error (e.g. to reset plotting state)
 const posterror_hooks = Function[]
@@ -297,7 +297,7 @@ push_posterror_hook(f::Function) = push!(posterror_hooks, f)
 Remove a function `f()` from the list of functions to
 execute after an error occurs when a notebook cell is evaluated.
 """
-pop_posterror_hook(f::Function) = splice!(posterror_hooks, findfirst(x -> x == posterror_hooks, f))
+pop_posterror_hook(f::Function) = @compat splice!(posterror_hooks, findfirst(equalto(f), posterror_hooks))
 
 #######################################################################
 

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -264,7 +264,7 @@ push_postexecute_hook(f::Function) = push!(postexecute_hooks, f)
 Remove a function `f()` from the list of functions to
 execute after executing any notebook cell.
 """
-pop_postexecute_hook(f::Function) = splice!(postexecute_hooks, findfirst(postexecute_hooks, f))
+pop_postexecute_hook(f::Function) = splice!(postexecute_hooks, findfirst(x -> x == postexecute_hooks, f))
 
 const preexecute_hooks = Function[]
 """
@@ -280,7 +280,7 @@ push_preexecute_hook(f::Function) = push!(preexecute_hooks, f)
 Remove a function `f()` from the list of functions to
 execute before executing any notebook cell.
 """
-pop_preexecute_hook(f::Function) = splice!(preexecute_hooks, findfirst(preexecute_hooks, f))
+pop_preexecute_hook(f::Function) = splice!(preexecute_hooks, findfirst(x -> x == preexecute_hooks, f))
 
 # similar, but called after an error (e.g. to reset plotting state)
 const posterror_hooks = Function[]
@@ -297,7 +297,7 @@ push_posterror_hook(f::Function) = push!(posterror_hooks, f)
 Remove a function `f()` from the list of functions to
 execute after an error occurs when a notebook cell is evaluated.
 """
-pop_posterror_hook(f::Function) = splice!(posterror_hooks, findfirst(posterror_hooks, f))
+pop_posterror_hook(f::Function) = splice!(posterror_hooks, findfirst(x -> x == posterror_hooks, f))
 
 #######################################################################
 

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -264,7 +264,7 @@ push_postexecute_hook(f::Function) = push!(postexecute_hooks, f)
 Remove a function `f()` from the list of functions to
 execute after executing any notebook cell.
 """
-pop_postexecute_hook(f::Function) = @compat splice!(postexecute_hooks, findfirst(equalto(f), postexecute_hooks))
+pop_postexecute_hook(f::Function) = splice!(postexecute_hooks, findfirst(equalto(f), postexecute_hooks))
 
 const preexecute_hooks = Function[]
 """
@@ -280,7 +280,7 @@ push_preexecute_hook(f::Function) = push!(preexecute_hooks, f)
 Remove a function `f()` from the list of functions to
 execute before executing any notebook cell.
 """
-pop_preexecute_hook(f::Function) = @compat splice!(preexecute_hooks, findfirst(equalto(f), preexecute_hooks))
+pop_preexecute_hook(f::Function) = splice!(preexecute_hooks, findfirst(equalto(f), preexecute_hooks))
 
 # similar, but called after an error (e.g. to reset plotting state)
 const posterror_hooks = Function[]
@@ -297,7 +297,7 @@ push_posterror_hook(f::Function) = push!(posterror_hooks, f)
 Remove a function `f()` from the list of functions to
 execute after an error occurs when a notebook cell is evaluated.
 """
-pop_posterror_hook(f::Function) = @compat splice!(posterror_hooks, findfirst(equalto(f), posterror_hooks))
+pop_posterror_hook(f::Function) = splice!(posterror_hooks, findfirst(equalto(f), posterror_hooks))
 
 #######################################################################
 

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -50,7 +50,7 @@ const displayqueue = Any[]
 
 # remove x from the display queue
 function undisplay(x)
-    i = @compat findfirst(equalto(x), displayqueue)
+    i = findfirst(equalto(x), displayqueue)
     if i > 0
         splice!(displayqueue, i)
     end

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -50,7 +50,7 @@ const displayqueue = Any[]
 
 # remove x from the display queue
 function undisplay(x)
-    i = findfirst(displayqueue, x)
+    i = findfirst(elem -> elem == displayqueue, x)
     if i > 0
         splice!(displayqueue, i)
     end

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -50,7 +50,7 @@ const displayqueue = Any[]
 
 # remove x from the display queue
 function undisplay(x)
-    i = findfirst(elem -> elem == displayqueue, x)
+    i = @compat findfirst(equalto(x), displayqueue)
     if i > 0
         splice!(displayqueue, i)
     end


### PR DESCRIPTION
`equalto` is only available in Julia 0.7. When support for Julia 0.6 is dropped, it can be changed to use `equalto`.

Closes #597.