### PR TITLE
Use uppercase, lowercase, and now from Compat

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.5
 MbedTLS 0.4.3
 JSON 0.5
 ZMQ 0.3.3
-Compat 0.40.0
+Compat 0.41.0
 Conda 0.1.5

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,7 @@
 #######################################################################
 import JSON, Conda
 using Compat
+using Compat.Unicode: lowercase
 
 jupyter=""
 

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -37,6 +37,8 @@ export notebook, installkernel
 
 using ZMQ, JSON, Compat
 import Compat.invokelatest
+using Compat.Unicode: uppercase, lowercase
+using Compat.Dates: now
 
 #######################################################################
 # Debugging IJulia


### PR DESCRIPTION
replaces #602 now that Compat.Unicode exists. This, along with https://github.com/JuliaInterop/ZMQ.jl/pull/161 , is enough to get me a working IJulia kernel on the latest nightly. 