### PR TITLE
Fix to allow installation on FreeBSD 11.1 STABLE

### DIFF
--- a/deps/kspec.jl
+++ b/deps/kspec.jl
@@ -75,7 +75,11 @@ function installkernel(name::AbstractString, julia_options::AbstractString...;
             run(`$jupyter kernelspec install --replace --user $juliakspec`)
             push!(kspec_cmd, jupyter, "kernelspec")
         catch
-            @static if Compat.Sys.isunix()
+
+            @static if Compat.Sys.isbsd()
+                run(`$jupyter-kernelspec-3.6 install --replace --user $juliakspec`)
+                push!(kspec_cmd, jupyter * "-kernelspec-3.6")
+            elseif Compat.Sys.isunix()
                 run(`$jupyter-kernelspec install --replace --user $juliakspec`)
                 push!(kspec_cmd, jupyter * "-kernelspec")
             end


### PR DESCRIPTION
FreeBSD appends Python version numbers to jupyter commands which breaks the IJulia build process. This quick and dirty fix allows installation for Python 3.6 on FreeBSD (the most recent version in FreeBSD 11.1 STABLE).

Are there any alternative workarounds using environment variables? Perhaps there could be a jupyterkernelspec environment variable for this?