### PR TITLE
Add vega-lite mime type

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -14,6 +14,7 @@ const text_markdown = MIME("text/markdown")
 const text_html = MIME("text/html")
 const text_latex = MIME("text/latex") # Jupyter expects this
 const text_latex2 = MIME("application/x-latex") # but this is more standard?
+const application_vnd_vegalite_v2 = MIME("application/vnd.vegalite.v2+json")
 
 include("magics.jl")
 
@@ -25,6 +26,9 @@ metadata(x) = Dict()
 # for passing to Jupyter display_data and execute_result messages.
 function display_dict(x)
     data = Dict{String,String}("text/plain" => limitstringmime(text_plain, x))
+    if mimewritable(application_vnd_vegalite_v2, x)
+        data[string(application_vnd_vegalite_v2)] = limitstringmime(application_vnd_vegalite_v2, x)
+    end
     if mimewritable(image_svg, x)
         data[string(image_svg)] = limitstringmime(image_svg, x)
     end

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -4,7 +4,7 @@ immutable InlineDisplay <: Display end
 
 # supported MIME types for inline display in IPython, in descending order
 # of preference (descending "richness")
-const ipy_mime = [ "text/html", "text/latex", "image/svg+xml", "image/png", "image/jpeg", "text/plain", "text/markdown", "application/javascript" ]
+const ipy_mime = [ "application/vnd.vegalite.v2+json", "text/html", "text/latex", "image/svg+xml", "image/png", "image/jpeg", "text/plain", "text/markdown", "application/javascript" ]
 
 # need special handling for showing a string as a textmime
 # type, since in that case the string is assumed to be


### PR DESCRIPTION
nteract supports this on ``master`` and JupyterLab just needs to update its support for vega-lite to v2.

This is not urgent, but will be nice once everything works together. The julia side of things is in https://github.com/fredo-dedup/VegaLite.jl.