### PR TITLE
Capture the parent message locally for idle messages

### DIFF
--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -17,7 +17,7 @@ function eventloop(socket)
                     send_ipython(publish[], msg_pub(execute_msg, "error", content))
                 end
             finally
-                # @async no longer implictly captures local variables #618
+                # @async no longer implicitly captures local variables (see PR #618)
                 let msg = msg
                     @async begin
                         sleep(idle_delay[])

--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -17,6 +17,7 @@ function eventloop(socket)
                     send_ipython(publish[], msg_pub(execute_msg, "error", content))
                 end
             finally
+                # @async no longer implictly captures local variables #618
                 let msg = msg
                     @async begin
                         sleep(idle_delay[])

--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -17,10 +17,12 @@ function eventloop(socket)
                     send_ipython(publish[], msg_pub(execute_msg, "error", content))
                 end
             finally
-                @async begin
-                    sleep(idle_delay[])
-                    flush_all()
-                    send_status("idle", msg)
+                let msg = msg
+                    @async begin
+                        sleep(idle_delay[])
+                        flush_all()
+                        send_status("idle", msg)
+                    end
                 end
             end
         end


### PR DESCRIPTION
On Julia 0.6, I am receiving idle messages with the wrong parent message ID. This only happens when there are multiple execute requests queued up. As an example,  if you run the cell

```sleep(3)```

Then

```sleep(2)```

Where `sleep(2)` is sent to the kernel before `sleep(3)` is finished executing, the idle message meant for `sleep(3)` will actually have the parent header of the `sleep(2)` request. It seems to be related to JuliaLang/julia#19594 which removes the behavior of `@async` to implicitly capture local variables.