### PR TITLE
Embed vega-lite JSON directly in JSON message

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -25,9 +25,9 @@ metadata(x) = Dict()
 # return a String=>String dictionary of mimetype=>data
 # for passing to Jupyter display_data and execute_result messages.
 function display_dict(x)
-    data = Dict{String,String}("text/plain" => limitstringmime(text_plain, x))
+    data = Dict{String,Any}("text/plain" => limitstringmime(text_plain, x))
     if mimewritable(application_vnd_vegalite_v2, x)
-        data[string(application_vnd_vegalite_v2)] = limitstringmime(application_vnd_vegalite_v2, x)
+        data[string(application_vnd_vegalite_v2)] = JSON.parse(limitstringmime(application_vnd_vegalite_v2, x))
     end
     if mimewritable(image_svg, x)
         data[string(image_svg)] = limitstringmime(image_svg, x)


### PR DESCRIPTION
I find this a bit weird, but both Jupyterlab and nteract expect it this way. For MIME types that are really JSON, they want the JSON of the payload to be just part of the message payload, not inside a string. That is how they then also embed it in the notebook files.

I've tested things with this PR, and it all works end-to-end on Jupyterlab and nteract with VegaLite.jl.