### PR TITLE
0.7 compatibility (mostly)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ os:
 julia:
   - 0.6
   - nightly
-matrix:
-  allow_failures:
-  - julia: nightly
 notifications:
   email: false
 script:

--- a/README.md
+++ b/README.md
@@ -186,11 +186,11 @@ is `IJulia.load("filename")`.
 
 ### Prompting for user input
 
-When you are running in a notebook, ordinary I/O functions on `STDIN` do
+When you are running in a notebook, ordinary I/O functions on `stdin` do
 not function.   However, you can prompt for the user to enter a string
 in one of two ways:
 
-* `readline()` and `readline(STDIN)` both open a `STDIN>` prompt widget where the user can enter a string, which is returned by `readline`.
+* `readline()` and `readline(stdin)` both open a `stdin>` prompt widget where the user can enter a string, which is returned by `readline`.
 
 * `IJulia.readprompt(prompt)` displays the prompt string `prompt` and
   returns a string entered by the user.  `IJulia.readprompt(prompt, password=true)` does the same thing but hides the text the user types.

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.6
 MbedTLS 0.4.3
 JSON 0.17
 ZMQ 0.6.0
-Compat 0.47.0
+Compat 0.68.0
 Conda 0.1.5

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,5 +2,5 @@ julia 0.6
 MbedTLS 0.4.3
 JSON 0.17
 ZMQ 0.6.0
-Compat 0.41.0
+Compat 0.47.0
 Conda 0.1.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,11 +10,6 @@ branches:
     - master
     - /release-.*/
 
-matrix:
-  allow_failures:
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
-
 notifications:
   - provider: Email
     on_build_success: false

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,7 +19,7 @@ function prog_version(prog)
         return nothing
     end
     try
-       return convert(VersionNumber, v)
+       return VersionNumber(v)
     catch
         warn("`$jupyter --version` returned an unrecognized version number $v")
         return v"0.0"
@@ -40,8 +40,8 @@ else
 end
 isconda = dirname(jupyter) == abspath(Conda.SCRIPTDIR)
 if Sys.ARCH in (:i686, :x86_64) && (jupyter_vers === nothing || jupyter_vers < v"3.0" || isconda)
-    isconda || jupyter_vers === nothing || info("$jupyter was too old: got $jupyter_vers, required ≥ 3.0")
-    info("Installing Jupyter via the Conda package.")
+    isconda || jupyter_vers === nothing || Compat.@info("$jupyter was too old: got $jupyter_vers, required ≥ 3.0")
+    Compat.@info("Installing Jupyter via the Conda package.")
     Conda.add("jupyter")
     jupyter = abspath(Conda.SCRIPTDIR, "jupyter")
     jupyter_vers = prog_version(jupyter)
@@ -49,7 +49,7 @@ end
 if jupyter_vers === nothing || jupyter_vers < v"3.0"
     error("Failed to find or install Jupyter 3.0 or later. Please install Jupyter manually, set `ENV[\"JUPYTER\"]=\"/path/to/jupyter\", and rerun `Pkg.build(\"IJulia\")`.")
 end
-info("Found Jupyter version $jupyter_vers: $jupyter")
+Compat.@info("Found Jupyter version $jupyter_vers: $jupyter")
 
 #######################################################################
 # Get the latest syntax highlighter file.
@@ -91,7 +91,7 @@ kspec_cmd, = installkernel("Julia")
 # "kernelspec" with "notebook":
 notebook = kspec_cmd.exec
 n = notebook[end]
-ki = rsearch(n, "kernelspec")
+ki = VERSION < v"0.7.0-DEV.3252" ? rsearch(n, "kernelspec") : findlast("kernelspec", n)
 notebook[end] = n[1:prevind(n,first(ki))] * "notebook" * n[nextind(n,last(ki)):end]
 
 #######################################################################

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -75,7 +75,7 @@ end
 # Warn people upgrading from older IJulia versions:
 try
     juliaprof = chomp(read(pipeline(`$ipython locate profile julia`,
-                                    stderr=DevNull), String))
+                                    stderr=devnull), String))
     warn("""You should now run IJulia just via `$jupyter notebook`, without
             the `--profile julia` flag.  IJulia no longer maintains the profile.
             Consider deleting $juliaprof""")

--- a/deps/kspec.jl
+++ b/deps/kspec.jl
@@ -4,7 +4,7 @@
 copy_config(src, dest) = cp(src, joinpath(dest, basename(src)), remove_destination=true)
 
 """
-    installkernel(name, options...; specname=replace(lowercase(name), " ", "-")
+    installkernel(name, options...; specname=replace(lowercase(name), " "=>"-")
 
 Install a new Julia kernel, where the given `options` are passed to the `julia`
 executable, and the user-visible kernel name is given by `name` followed by the
@@ -31,7 +31,7 @@ run(`\$kernelspec remove -f \$kernelname`)
 ```
 """
 function installkernel(name::AbstractString, julia_options::AbstractString...;
-                   specname::AbstractString = replace(lowercase(name), " ", "-"))
+                   specname::AbstractString = replace(lowercase(name), " "=>"-"))
     # Is IJulia being built from a debug build? If so, add "debug" to the description.
     debugdesc = ccall(:jl_is_debugbuild,Cint,())==1 ? "-debug" : ""
 
@@ -41,7 +41,7 @@ function installkernel(name::AbstractString, julia_options::AbstractString...;
     juliakspec = joinpath(tempdir(), spec_name)
     try
         binary_name = Compat.Sys.iswindows() ? "julia.exe" : "julia"
-        kernelcmd_array = String[joinpath(JULIA_HOME,"$binary_name"), "-i",
+        kernelcmd_array = String[joinpath(Compat.Sys.BINDIR,"$binary_name"), "-i",
                                  "--startup-file=yes", "--color=yes"]
         append!(kernelcmd_array, julia_options)
         ijulia_dir = get(ENV, "IJULIA_DIR", dirname(@__DIR__)) # support non-Pkg IJulia installs
@@ -65,7 +65,7 @@ function installkernel(name::AbstractString, julia_options::AbstractString...;
         copy_config(joinpath(ijulia_dir,"deps","logo-32x32.png"), juliakspec)
         copy_config(joinpath(ijulia_dir,"deps","logo-64x64.png"), juliakspec)
 
-        info("Installing $name kernelspec $spec_name")
+        Compat.@info("Installing $name kernelspec $spec_name")
 
         # remove these hacks when
         # https://github.com/jupyter/notebook/issues/448 is closed and the fix

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -41,15 +41,8 @@ using Compat.Unicode: uppercase, lowercase
 import Compat.Dates
 using Compat.Dates: now
 import Compat.Random
-
-if VERSION ≥ v"0.7.0-DEV.2338" # julia#24361
-  using Base64: Base64EncodePipe
-end
-if isdefined(Base, :REPL) && !Base.isdeprecated(Base, :REPL)
-  import Base.REPL
-else
-  import REPL
-end
+using Compat.Base64: Base64EncodePipe
+using Compat.REPL
 
 #######################################################################
 # Debugging IJulia

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -38,7 +38,18 @@ export notebook, installkernel
 using ZMQ, JSON, Compat
 import Compat.invokelatest
 using Compat.Unicode: uppercase, lowercase
+import Compat.Dates
 using Compat.Dates: now
+import Compat.Random
+
+if VERSION ≥ v"0.7.0-DEV.2338" # julia#24361
+  using Base64: Base64EncodePipe
+end
+if isdefined(Base, :REPL) && !Base.isdeprecated(Base, :REPL)
+  import Base.REPL
+else
+  import REPL
+end
 
 #######################################################################
 # Debugging IJulia
@@ -198,7 +209,7 @@ function clear_history(indices)
 end
 
 # since a range could be huge, intersect it with 1:n first
-clear_history{T<:Integer}(r::AbstractRange{T}) =
+clear_history(r::AbstractRange{T}) where {T<:Integer} =
     invoke(clear_history, Tuple{Any}, intersect(r, 1:n))
 
 function clear_history()

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -243,7 +243,7 @@ function history(io::IO, indices::AbstractVector{Int})
 end
 
 history(io::IO, x::Union{Integer,AbstractVector{Int}}...) = history(io, vcat(x...))
-history(x...) = history(STDOUT, x...)
+history(x...) = history(stdout, x...)
 history(io::IO, x...) = throw(MethodError(history, (x...,)))
 history() = history(1:n)
 """
@@ -256,7 +256,7 @@ The optional `indices` argument is one or more indices or collections
 of indices indicating a subset input cells to print.
 
 The optional `io` argument is for specifying an output stream. The default
-is `STDOUT`.
+is `stdout`.
 """
 history
 

--- a/src/comm_manager.jl
+++ b/src/comm_manager.jl
@@ -7,12 +7,12 @@ import IJulia: Msg, uuid4, send_ipython, msg_pub
 export Comm, comm_target, msg_comm, send_comm, close_comm,
        register_comm, comm_msg, comm_open, comm_close, comm_info_request
 
-type Comm{target}
+mutable struct Comm{target}
     id::String
     primary::Bool
     on_msg::Function
     on_close::Function
-    function (::Type{Comm{target}}){target}(id, primary, on_msg, on_close)
+    function (::Type{Comm{target}})(id, primary, on_msg, on_close) where {target}
         comm = new{target}(id, primary, on_msg, on_close)
         comms[id] = comm
         return comm
@@ -42,7 +42,7 @@ function Comm(target,
     return comm
 end
 
-comm_target{target}(comm :: Comm{target}) = target
+comm_target(comm :: Comm{target}) where {target} = target
 
 function comm_info_request(sock, msg)
     reply = if haskey(msg.content, "target_name")

--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -13,7 +13,7 @@ function eventloop(socket)
                 #  kernel interruption to interrupt long calculations.)
                 if !isa(e, InterruptException)
                     content = error_content(e, msg="KERNEL EXCEPTION")
-                    map(s -> println(orig_STDERR[], s), content["traceback"])
+                    map(s -> println(orig_stderr[], s), content["traceback"])
                     send_ipython(publish[], msg_pub(execute_msg, "error", content))
                 end
             finally

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -25,27 +25,27 @@ metadata(x) = Dict()
 # for passing to Jupyter display_data and execute_result messages.
 function display_dict(x)
     data = Dict{String,Any}("text/plain" => limitstringmime(text_plain, x))
-    if mimewritable(application_vnd_vegalite_v2, x)
+    if showable(application_vnd_vegalite_v2, x)
         data[string(application_vnd_vegalite_v2)] = JSON.JSONText(limitstringmime(application_vnd_vegalite_v2, x))
     end
-    if mimewritable(application_vnd_dataresource, x)
+    if showable(application_vnd_dataresource, x)
         data[string(application_vnd_dataresource)] = JSON.JSONText(limitstringmime(application_vnd_dataresource, x))
     end
-    if mimewritable(image_svg, x)
+    if showable(image_svg, x)
         data[string(image_svg)] = limitstringmime(image_svg, x)
     end
-    if mimewritable(image_png, x)
+    if showable(image_png, x)
         data[string(image_png)] = limitstringmime(image_png, x)
-    elseif mimewritable(image_jpeg, x) # don't send jpeg if we have png
+    elseif showable(image_jpeg, x) # don't send jpeg if we have png
         data[string(image_jpeg)] = limitstringmime(image_jpeg, x)
     end
-    if mimewritable(text_markdown, x)
+    if showable(text_markdown, x)
         data[string(text_markdown)] = limitstringmime(text_markdown, x)
-    elseif mimewritable(text_html, x)
+    elseif showable(text_html, x)
         data[string(text_html)] = limitstringmime(text_html, x)
-    elseif mimewritable(text_latex, x)
+    elseif showable(text_latex, x)
         data[string(text_latex)] = limitstringmime(text_latex, x)
-    elseif mimewritable(text_latex2, x)
+    elseif showable(text_latex2, x)
         data[string(text_latex)] = limitstringmime(text_latex2, x)
     end
     return data
@@ -56,7 +56,7 @@ const displayqueue = Any[]
 
 # remove x from the display queue
 function undisplay(x)
-    i = findfirst(equalto(x), displayqueue)
+    i = findfirst(isequal(x), displayqueue)
     if i !== nothing && i > 0
         splice!(displayqueue, i)
     end
@@ -113,6 +113,8 @@ end
 # use a global array to accumulate "payloads" for the execute_reply message
 const execute_payloads = Dict[]
 
+const stdout_name = isdefined(Base, :stdout) ? "stdout" : "STDOUT"
+
 function execute_request(socket, msg)
     code = msg.content["code"]
     @vprintln("EXECUTING ", code)
@@ -139,7 +141,7 @@ function execute_request(socket, msg)
     # "; ..." cells are interpreted as shell commands for run
     code = replace(code, r"^\s*;.*$" =>
                    m -> string(replace(m, r"^\s*;", "Base.repl_cmd(`"),
-                               "`, STDOUT)"))
+                               "`, ", stdout_name, ")"))
 
     # a cell beginning with "? ..." is interpreted as a help request
     hcode = replace(code, r"^\s*\?" => "")
@@ -151,10 +153,10 @@ function execute_request(socket, msg)
 
 
         if hcode != code # help request
-            eval(Main, helpmode(hcode))
+            Core.eval(Main, helpmode(hcode))
         else
             #run the code!
-            ans = result = contains(code, magics_regex) ? magics_help(code) :
+            ans = result = occursin(magics_regex, code) ? magics_help(code) :
                 include_string(current_module[], code, "In[$n]")
         end
 

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -63,9 +63,15 @@ function undisplay(x)
     return x
 end
 
+if VERSION < v"0.7.0-DEV.3498" # julia #25544
+    import Base.REPL: ip_matches_func 
+else
+    import Base: ip_matches_func 
+end
+
 function show_bt(io::IO, top_func::Symbol, t, set)
     # follow PR #17570 code in removing top_func from backtrace
-    eval_ind = findlast(addr->REPL.ip_matches_func(addr, top_func), t)
+    eval_ind = findlast(addr->ip_matches_func(addr, top_func), t)
     eval_ind !== nothing && eval_ind != 0 && (t = t[1:eval_ind-1])
     Base.show_backtrace(io, t)
 end
@@ -74,12 +80,26 @@ end
 # doesn't support keyword arguments.
 showerror_nobt(io, e, bt) = showerror(io, e, bt, backtrace=false)
 
+@static if VERSION < v"0.7.0-DEV.4724"
+		# https://github.com/JuliaLang/Compat.jl/pull/572
+    # thanks to https://github.com/jipolanco/WriteVTK.jl/commit/ea046493c7787ae651b5f629455aaf7bdaa000b1
+    rsplit(s::AbstractString; limit::Integer=0, keepempty::Bool=false) =
+        Base.rsplit(s)
+    rsplit(s::AbstractString, splitter; limit::Integer=0, keepempty::Bool=false) =
+        Base.rsplit(s, splitter; limit=limit, keep=keepempty)
+    split(s::AbstractString; limit::Integer=0, keepempty::Bool=false) =
+        Base.split(s)
+    split(s::AbstractString, splitter; limit::Integer=0, keepempty::Bool=false) =
+        Base.split(s, splitter; limit=limit, keep=keepempty)
+end
+
 # return the content of a pyerr message for exception e
 function error_content(e, bt=catch_backtrace(); backtrace_top::Symbol=:include_string, msg::AbstractString="")
     tb = map(x->String(x), split(sprint(show_bt,
                                         backtrace_top,
                                         bt, 1:typemax(Int)),
-                                 "\n", keep=true))
+                                  "\n", keepempty=true))
+
     ename = string(typeof(e))
     evalue = try
         # Peel away one LoadError layer that comes from running include_string on the cell

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -64,9 +64,9 @@ function undisplay(x)
 end
 
 if VERSION < v"0.7.0-DEV.3498" # julia #25544
-    import Base.REPL: ip_matches_func 
+    import Base.REPL: ip_matches_func
 else
-    import Base: ip_matches_func 
+    import Base: ip_matches_func
 end
 
 function show_bt(io::IO, top_func::Symbol, t, set)

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -51,7 +51,10 @@ Base.ind2chr(m::Msg, str::String, i::Integer) = i == 0 ? 0 :
     VersionNumber(m.header["version"]) ≥ v"5.2" ? ind2chr(str, i) : ind_to_utf16(str, i)
 #Compact display of types for Jupyterlab completion
 
-if isdefined(Main, :REPLCompletions)
+if VERSION ≥ v"0.7.0-DEV.3500" #25544
+    import REPL
+    import REPL.REPLCompletions: sorted_keywords, emoji_symbols, latex_symbols
+elseif isdefined(Main, :REPLCompletions)
     import REPLCompletions: sorted_keywords, emoji_symbols, latex_symbols
 else
     const sorted_keywords = [

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -109,7 +109,7 @@ function complete_types(comps)
             expr = Meta.parse(c, raise=false)
             if typeof(expr) == Symbol
                 try
-                    ctype = complete_type(eval(current_module[], :(typeof($expr))))
+                    ctype = complete_type(Core.eval(current_module[], :(typeof($expr))))
                 end
             elseif !isa(expr, Expr)
                 ctype = complete_type(expr)
@@ -200,7 +200,7 @@ function shutdown_request(socket, msg)
     exit()
 end
 
-docdict(s::AbstractString) = display_dict(eval(Main, helpmode(DevNull, s)))
+docdict(s::AbstractString) = display_dict(Core.eval(Main, helpmode(devnull, s)))
 
 import Base: is_id_char, is_id_start_char
 function get_token(code, pos)

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -52,7 +52,6 @@ Base.ind2chr(m::Msg, str::String, i::Integer) = i == 0 ? 0 :
 #Compact display of types for Jupyterlab completion
 
 if VERSION ≥ v"0.7.0-DEV.3500" #25544
-    import REPL
     import REPL.REPLCompletions: sorted_keywords, emoji_symbols, latex_symbols
 elseif isdefined(Main, :REPLCompletions)
     import REPLCompletions: sorted_keywords, emoji_symbols, latex_symbols

--- a/src/heartbeat.jl
+++ b/src/heartbeat.jl
@@ -6,16 +6,17 @@
 
 
 const threadid = zeros(Int, 128) # sizeof(uv_thread_t) <= 8 on Linux, OSX, Win
+using ZMQ: libzmq
 
 # entry point for new thread
 function heartbeat_thread(sock::Ptr{Cvoid})
-    ccall((:zmq_proxy,ZMQ.libzmq), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+    ccall((:zmq_proxy,libzmq), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
           sock, sock, C_NULL)
     nothing
 end
 
 function start_heartbeat(sock)
-    heartbeat_c = cfunction(heartbeat_thread, Cvoid, Tuple{Ptr{Cvoid}})
+    heartbeat_c = @cfunction(heartbeat_thread, Cvoid, (Ptr{Cvoid},))
     ccall(:uv_thread_create, Cint, (Ptr{Int}, Ptr{Cvoid}, Ptr{Cvoid}),
           threadid, heartbeat_c, sock.data)
 end

--- a/src/heartbeat.jl
+++ b/src/heartbeat.jl
@@ -6,7 +6,6 @@
 
 
 const threadid = zeros(Int, 128) # sizeof(uv_thread_t) <= 8 on Linux, OSX, Win
-const libzmq = ZMQ.zmq
 
 # entry point for new thread
 function heartbeat_thread(sock::Ptr{Cvoid})

--- a/src/heartbeat.jl
+++ b/src/heartbeat.jl
@@ -4,15 +4,19 @@
 # call in libzmq, which simply blocks forever, so the usual lack of
 # thread safety in Julia should not be an issue here.
 
+
+const threadid = zeros(Int, 128) # sizeof(uv_thread_t) <= 8 on Linux, OSX, Win
+const libzmq = ZMQ.zmq
+
 # entry point for new thread
-function heartbeat_thread(sock::Ptr{Void})
-    ccall((:zmq_proxy,ZMQ.libzmq), Cint, (Ptr{Void}, Ptr{Void}, Ptr{Void}),
+function heartbeat_thread(sock::Ptr{Cvoid})
+    ccall((:zmq_proxy,ZMQ.libzmq), Cint, (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
           sock, sock, C_NULL)
     nothing
 end
 
 function start_heartbeat(sock)
-    heartbeat_c = cfunction(heartbeat_thread, Void, Tuple{Ptr{Void}})
-    ccall(:uv_thread_create, Cint, (Ptr{Int}, Ptr{Void}, Ptr{Void}),
+    heartbeat_c = cfunction(heartbeat_thread, Cvoid, Tuple{Ptr{Cvoid}})
+    ccall(:uv_thread_create, Cint, (Ptr{Int}, Ptr{Cvoid}, Ptr{Cvoid}),
           threadid, heartbeat_c, sock.data)
 end

--- a/src/hmac.jl
+++ b/src/hmac.jl
@@ -11,7 +11,7 @@ function hmac(s1,s2,s3,s4)
         end
         # Take the digest (returned as a byte array) and convert it to hex string representation
         digest = MbedTLS.finish!(hmacstate[])
-        hexdigest = Vector{UInt8}(uninitialized, length(digest)*2)
+        hexdigest = Vector{UInt8}(undef, length(digest)*2)
         for i = 1:length(digest)
             b = digest[i]
             d = b >> 4

--- a/src/hmac.jl
+++ b/src/hmac.jl
@@ -11,7 +11,7 @@ function hmac(s1,s2,s3,s4)
         end
         # Take the digest (returned as a byte array) and convert it to hex string representation
         digest = MbedTLS.finish!(hmacstate[])
-        hexdigest = Vector{UInt8}(length(digest)*2)
+        hexdigest = Vector{UInt8}(uninitialized, length(digest)*2)
         for i = 1:length(digest)
             b = digest[i]
             d = b >> 4

--- a/src/init.jl
+++ b/src/init.jl
@@ -13,14 +13,14 @@ else
     uuid4() = repr(UUIDs.uuid4(IJulia_RNG))
 end
 
-const orig_STDIN  = Ref{IO}()
-const orig_STDOUT = Ref{IO}()
-const orig_STDERR = Ref{IO}()
+const orig_stdin  = Ref{IO}()
+const orig_stdout = Ref{IO}()
+const orig_stderr = Ref{IO}()
 function __init__()
     Random.srand(IJulia_RNG)
-    orig_STDIN[]  = STDIN
-    orig_STDOUT[] = STDOUT
-    orig_STDERR[] = STDERR
+    orig_stdin[]  = stdin
+    orig_stdout[] = stdout
+    orig_stderr[] = stderr
 end
 
 # the following constants need to be initialized in init().
@@ -103,13 +103,13 @@ function init(args)
     start_heartbeat(heartbeat[])
     if capture_stdout
         read_stdout[], = redirect_stdout()
-        redirect_stdout(IJuliaStdio(STDOUT,"stdout"))
+        redirect_stdout(IJuliaStdio(stdout,"stdout"))
     end
     if capture_stderr
         read_stderr[], = redirect_stderr()
-        redirect_stderr(IJuliaStdio(STDERR,"stderr"))
+        redirect_stderr(IJuliaStdio(stderr,"stderr"))
     end
-    redirect_stdin(IJuliaStdio(STDIN,"stdin"))
+    redirect_stdin(IJuliaStdio(stdin,"stdin"))
 
     send_status("starting")
     global inited = true

--- a/src/init.jl
+++ b/src/init.jl
@@ -5,20 +5,23 @@ include(joinpath("..","deps","kspec.jl"))
 
 # use our own random seed for msg_id so that we
 # don't alter the user-visible random state (issue #336)
-const IJulia_RNG = srand(MersenneTwister(0))
-uuid4() = repr(Base.Random.uuid4(IJulia_RNG))
+const IJulia_RNG = Random.srand(Random.MersenneTwister(0))
+@static if VERSION < v"0.7.0-DEV.3666" # julia#25819
+    uuid4() = repr(Random.uuid4(IJulia_RNG))
+else
+    import UUIDs
+    uuid4() = repr(UUIDs.uuid4(IJulia_RNG))
+end
 
 const orig_STDIN  = Ref{IO}()
 const orig_STDOUT = Ref{IO}()
 const orig_STDERR = Ref{IO}()
 function __init__()
-    srand(IJulia_RNG)
+    Random.srand(IJulia_RNG)
     orig_STDIN[]  = STDIN
     orig_STDOUT[] = STDOUT
     orig_STDERR[] = STDERR
 end
-
-const threadid = Vector{Int}(128) # sizeof(uv_thread_t) <= 8 on Linux, OSX, Win
 
 # the following constants need to be initialized in init().
 const ctx = Ref{Context}()

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -1,6 +1,9 @@
 import Base: display, redisplay
 
-immutable InlineDisplay <: Display end
+@static if !isdefined(Base, :AbstractDisplay) # remove when Compat.jl#482 is merged and tagged
+    const AbstractDisplay = Display
+end
+struct InlineDisplay <: AbstractDisplay end
 
 # supported MIME types for inline display in IPython, in descending order
 # of preference (descending "richness")

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -1,4 +1,5 @@
 import IJulia
+using Compat
 
 # workaround #60:
 if IJulia.Compat.Sys.isapple()

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -19,13 +19,13 @@ ccall(:jl_exit_on_sigint, IJulia.Compat.Cvoid, (Cint,), 0)
 ENV["LINES"] = get(ENV, "LINES", 30)
 ENV["COLUMNS"] = get(ENV, "COLUMNS", 80)
 
-println(IJulia.orig_STDOUT[], "Starting kernel event loops.")
+println(IJulia.orig_stdout[], "Starting kernel event loops.")
 IJulia.watch_stdio()
 
 # workaround JuliaLang/julia#4259
 delete!(task_local_storage(),:SOURCE_PATH)
 
 # workaround JuliaLang/julia#6765
-eval(Base, :(is_interactive = true))
+Core.eval(Base, :(is_interactive = true))
 
 IJulia.waitloop()

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -2,7 +2,7 @@ import IJulia
 
 # workaround #60:
 if IJulia.Compat.Sys.isapple()
-    ENV["PATH"] = JULIA_HOME*":"*ENV["PATH"]
+    ENV["PATH"] = IJulia.Compat.Sys.BINDIR*":"*ENV["PATH"]
 end
 
 IJulia.init(ARGS)
@@ -12,7 +12,7 @@ import IJulia: ans, In, Out, clear_history
 
 pushdisplay(IJulia.InlineDisplay())
 
-ccall(:jl_exit_on_sigint, Void, (Cint,), 0)
+ccall(:jl_exit_on_sigint, Cvoid, (Cint,), 0)
 
 # the size of truncated output to show should not depend on the terminal
 # where the kernel is launched, since the display is elsewhere

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -1,5 +1,4 @@
 import IJulia
-using Compat
 
 # workaround #60:
 if IJulia.Compat.Sys.isapple()
@@ -13,7 +12,7 @@ import IJulia: ans, In, Out, clear_history
 
 pushdisplay(IJulia.InlineDisplay())
 
-ccall(:jl_exit_on_sigint, Cvoid, (Cint,), 0)
+ccall(:jl_exit_on_sigint, IJulia.Compat.Cvoid, (Cint,), 0)
 
 # the size of truncated output to show should not depend on the terminal
 # where the kernel is launched, since the display is elsewhere

--- a/src/magics.jl
+++ b/src/magics.jl
@@ -59,7 +59,7 @@ alias_magic_help(magic::AbstractString, args::AbstractString) = md"""
     which you can then run with e.g. `bracket("hello world")`."""
 
 function cd_magic_help(magic::AbstractString, args::AbstractString)
-    if magic == "%cd" && !contains(args, r"\s*-")
+    if magic == "%cd" && !occursin(r"\s*-", args)
         return md"""The equivalent of `%cd 'dir'` in IPython is `cd("dir")` in Julia."""
     else
         return md"""
@@ -217,7 +217,7 @@ prun_magic_help(magic::AbstractString, args::AbstractString) = md"""
 
 psearch_magic_help(magic::AbstractString, args::AbstractString) = md"""
     A rough analogue of IPython's `%psearch PATTERN` in Julia might be
-    `filter(s -> contains(string(s), r"PATTERN"), names(Base))`, which
+    `filter(s -> occursin(r"PATTERN", string(s)), names(Base))`, which
     searches all the symbols defined in the `Base` module for a given
     regular-expression pattern `PATTERN`."""
 
@@ -349,7 +349,7 @@ function pipe_magic_help(magic::AbstractString, args::AbstractString)
     The analogue of IPython's `$magic ...code...` in Julia can be
     constructed by first evaluating
     ```
-    macro $(cmd)_str(s) open(`$cmd`,"w",STDOUT) do io; print(io, s); end; end
+    macro $(cmd)_str(s) open(`$cmd`,"w",stdout) do io; print(io, s); end; end
     ```
     to define the `$cmd"...."` [string macro](http://docs.julialang.org/en/latest/manual/strings/#non-standard-string-literals)
     in Julia.  Subsequently, you can simply do:
@@ -358,7 +358,7 @@ function pipe_magic_help(magic::AbstractString, args::AbstractString)
     ...code...
     ""\"
     ```
-    to evaluate the code in `$cmd` (outputting to `STDOUT`).""")
+    to evaluate the code in `$cmd` (outputting to `stdout`).""")
 end
 
 svg_magic_help(magic::AbstractString, args::AbstractString) = md"""

--- a/src/magics.jl
+++ b/src/magics.jl
@@ -23,7 +23,11 @@ function magics_help(code::AbstractString)
     end
 end
 
-using Base.Markdown
+@static if VERSION < v"0.7.0-DEV.3589" # julia#25738
+    using Base.Markdown
+else
+    using Markdown
+end
 
 const magic_help_string = """
     Julia does not use the IPython `%magic` syntax.   To interact
@@ -55,7 +59,7 @@ alias_magic_help(magic::AbstractString, args::AbstractString) = md"""
     which you can then run with e.g. `bracket("hello world")`."""
 
 function cd_magic_help(magic::AbstractString, args::AbstractString)
-    if magic == "%cd" && !ismatch(r"\s*-", args)
+    if magic == "%cd" && !contains(args, r"\s*-")
         return md"""The equivalent of `%cd 'dir'` in IPython is `cd("dir")` in Julia."""
     else
         return md"""
@@ -213,7 +217,7 @@ prun_magic_help(magic::AbstractString, args::AbstractString) = md"""
 
 psearch_magic_help(magic::AbstractString, args::AbstractString) = md"""
     A rough analogue of IPython's `%psearch PATTERN` in Julia might be
-    `filter(s -> ismatch(r"PATTERN", string(s)), names(Base))`, which
+    `filter(s -> contains(string(s), r"PATTERN"), names(Base))`, which
     searches all the symbols defined in the `Base` module for a given
     regular-expression pattern `PATTERN`."""
 

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -3,7 +3,7 @@ import Base.show
 export Msg, msg_pub, msg_reply, send_status, send_ipython
 
 # IPython message structure
-type Msg
+mutable struct Msg
     idents::Vector{String}
     header::Dict
     content::Dict

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -1,4 +1,4 @@
-# IJulia redirects STDOUT and STDERR into "stream" messages sent to the
+# IJulia redirects stdout and stderr into "stream" messages sent to the
 # Jupyter front-end.
 
 # create a wrapper type around redirected stdio streams,
@@ -30,7 +30,7 @@ for s in ("stdout", "stderr", "stdin")
     S = QuoteNode(Symbol(uppercase(s)))
     @eval function Base.$f(io::IJuliaStdio)
         io[:jupyter_stream] != $s && throw(ArgumentError(string("expecting ", $s, " stream")))
-        eval(Base, Expr(:(=), $S, io))
+        Core.eval(Base, Expr(:(=), $S, io))
         return io
     end
 end
@@ -49,7 +49,7 @@ end
 macro vprintln(x...)
     quote
         if verbose::Bool
-            println(orig_STDOUT[], get_log_preface(), $(map(esc, x)...))
+            println(orig_stdout[], get_log_preface(), $(map(esc, x)...))
         end
     end
 end
@@ -57,7 +57,7 @@ end
 macro verror_show(e, bt)
     quote
         if verbose::Bool
-            showerror(orig_STDERR[], $(esc(e)), $(esc(bt)))
+            showerror(orig_stderr[], $(esc(e)), $(esc(bt)))
         end
     end
 end
@@ -216,7 +216,7 @@ end
 import Base.readline
 function readline(io::IJuliaStdio)
     if get(io,:jupyter_stream,"unknown") == "stdin"
-        return readprompt("STDIN> ")
+        return readprompt("stdin> ")
     else
         readline(io.io)
     end
@@ -232,7 +232,7 @@ function watch_stdio()
     task_local_storage(:IJulia_task, "init task")
     if capture_stdout
         read_task = @async watch_stream(read_stdout[], "stdout")
-        #send STDOUT stream msgs every stream_interval secs (if there is output to send)
+        #send stdout stream msgs every stream_interval secs (if there is output to send)
         _Timer(send_stdout, stream_interval, stream_interval)
     end
     if capture_stderr
@@ -244,8 +244,8 @@ end
 
 function flush_all()
     flush_cstdio() # flush writes to stdout/stderr by external C code
-    flush(STDOUT)
-    flush(STDERR)
+    flush(stdout)
+    flush(stderr)
 end
 
 function oslibuv_flush()

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -27,7 +27,7 @@ Base.setup_stdio(io::IJuliaStdio, readable::Bool) = Base.setup_stdio(io.io.io, r
 
 for s in ("stdout", "stderr", "stdin")
     f = Symbol("redirect_", s)
-    S = QuoteNode(Symbol(uppercase(s)))
+    S = QuoteNode(Symbol(isdefined(Base, :stdout) ? s : uppercase(s)))
     @eval function Base.$f(io::IJuliaStdio)
         io[:jupyter_stream] != $s && throw(ArgumentError(string("expecting ", $s, " stream")))
         Core.eval(Base, Expr(:(=), $S, io))

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -4,7 +4,7 @@
 # create a wrapper type around redirected stdio streams,
 # both for overloading things like `flush` and so that we
 # can set properties like `color`.
-immutable IJuliaStdio{IO_t <: IO} <: Base.AbstractPipe
+struct IJuliaStdio{IO_t <: IO} <: Base.AbstractPipe
     io::IOContext{IO_t}
 end
 IJuliaStdio(io::IO, stream::AbstractString="unknown") =
@@ -38,6 +38,7 @@ end
 # logging in verbose mode goes to original stdio streams.  Use macros
 # so that we do not even evaluate the arguments in no-verbose modes
 
+using Compat.Printf
 function get_log_preface()
     t = now()
     taskname = get(task_local_storage(), :IJulia_task, "")
@@ -82,7 +83,7 @@ function watch_stream(rd::IO, name::AbstractString)
         buf = IOBuffer()
         bufs[name] = buf
         while !eof(rd) # blocks until something is available
-            nb = nb_available(rd)
+            nb = @static VERSION < v"0.7.0-DEV.3481" ? nb_available(rd) : bytesavailable(rd)
             if nb > 0
                 stdio_bytes[] += nb
                 # if this stream has surpassed the maximum output limit then ignore future bytes
@@ -221,17 +222,23 @@ function readline(io::IJuliaStdio)
     end
 end
 
+if VERSION < v"0.7.0-DEV.3526" # julia#25647
+    _Timer(callback, delay, repeat) = Timer(callback, delay, repeat)
+else
+    _Timer(callback, delay, repeat) = Timer(callback, delay, interval=repeat)
+end
+
 function watch_stdio()
     task_local_storage(:IJulia_task, "init task")
     if capture_stdout
         read_task = @async watch_stream(read_stdout[], "stdout")
         #send STDOUT stream msgs every stream_interval secs (if there is output to send)
-        Timer(send_stdout, stream_interval, stream_interval)
+        _Timer(send_stdout, stream_interval, stream_interval)
     end
     if capture_stderr
         readerr_task = @async watch_stream(read_stderr[], "stderr")
         #send STDERR stream msgs every stream_interval secs (if there is output to send)
-        Timer(send_stderr, stream_interval, stream_interval)
+        _Timer(send_stderr, stream_interval, stream_interval)
     end
 end
 
@@ -245,7 +252,7 @@ function oslibuv_flush()
     #refs: https://github.com/JuliaLang/IJulia.jl/issues/347#issuecomment-144505862
     #      https://github.com/JuliaLang/IJulia.jl/issues/347#issuecomment-144605024
     @static if Compat.Sys.iswindows()
-        ccall(:SwitchToThread, stdcall, Void, ())
+        ccall(:SwitchToThread, stdcall, Cvoid, ())
     end
     yield()
     yield()

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -45,7 +45,6 @@ function get_log_preface()
     @sprintf("%02d:%02d:%02d(%s): ", Dates.hour(t),Dates.minute(t),Dates.second(t),taskname)
 end
 
-
 macro vprintln(x...)
     quote
         if verbose::Bool

--- a/test/comm.jl
+++ b/test/comm.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Compat.Test
 import IJulia: Comm, comm_target
 
 

--- a/test/execute_request.jl
+++ b/test/execute_request.jl
@@ -1,6 +1,6 @@
 using Compat.Test
 
-import IJulia: helpcode, error_content, docdict
+import IJulia: helpmode, error_content, docdict
 
 content = error_content(UndefVarError(:a))
 @test "UndefVarError" == content["ename"]

--- a/test/execute_request.jl
+++ b/test/execute_request.jl
@@ -1,14 +1,9 @@
-using Base.Test
+using Compat.Test
 
-import IJulia: helpcode, error_content
-
-@test !haskey(Docs.keywords, :+)
-@test "Base.Docs.@repl +" == helpcode("+")
-
-@test haskey(Docs.keywords, :import)
-@test """eval(:(Base.Docs.@repl \$(Symbol("import"))))""" == helpcode("import")
+import IJulia: helpcode, error_content, docdict
 
 content = error_content(UndefVarError(:a))
 @test "UndefVarError" == content["ename"]
 
-@test haskey(IJulia.docdict("sum"), "text/plain")
+@test haskey(docdict("import"), "text/plain")
+@test haskey(docdict("sum"), "text/plain")

--- a/test/msg.jl
+++ b/test/msg.jl
@@ -1,5 +1,6 @@
-using Base.Test
+using Compat.Test
 import IJulia: Msg
+using Compat.Dates
 
 idents = ["idents"]
 header = Dict("msg_id"=>"c673eed8-7c36-47f4-82af-df8ec546a87d",

--- a/test/stdio.jl
+++ b/test/stdio.jl
@@ -1,4 +1,4 @@
-using Base.Test
+using Compat.Test
 using IJulia
 
 mktemp() do path, io
@@ -7,7 +7,7 @@ mktemp() do path, io
     end
     flush(io)
     seek(io, 0)
-    @test readstring(io) == "print\n"
+    @test read(io, String) == "print\n"
     @test_throws ArgumentError redirect_stdout(IJulia.IJuliaStdio(io, "stderr"))
     @test_throws ArgumentError redirect_stdout(IJulia.IJuliaStdio(io, "stdin"))
     @test_throws ArgumentError redirect_stderr(IJulia.IJuliaStdio(io, "stdout"))
@@ -22,7 +22,7 @@ mktemp() do path, io
     end
     flush(io)
     seek(io, 0)
-    captured = readstring(io)
+    captured = read(io, String)
     @test (captured == "\e[1m\e[33mWARNING: \e[39m\e[22m\e[33mwarn\e[39m\n" ||
            captured == "WARNING: warn\n")  # output will differ based on whether color is currently enabled
 end


### PR DESCRIPTION
This fixes most of the 0.7 compatibility issues.  (Closes #637.  Should close #646 too.)

Notebooks can now start and execute cells without deprecation warnings (assuming you have JSON and ZMQ master).  Documentation tooltips work.   Tests pass.

Some things are still broken, e.g. stdio seems borked at the moment.