### PR TITLE
Add metadata to complete_reply

### DIFF
--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -107,7 +107,6 @@ function complete_types(comps)
             if typeof(expr) == Symbol
                 try
                     ctype = complete_type(eval(Main, :(typeof($expr))))
-                catch
                 end
             elseif !isa(expr, Expr)
                 ctype = complete_type(expr)

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -50,7 +50,7 @@ Base.chr2ind(m::Msg, str::String, ic::Integer) = ic == 0 ? 0 :
 Base.ind2chr(m::Msg, str::String, i::Integer) = i == 0 ? 0 :
     VersionNumber(m.header["version"]) ≥ v"5.2" ? ind2chr(str, i) : ind_to_utf16(str, i)
 #Compact display of types for Jupyterlab completion
-complete_type(T) = string(T) # maybe shorten?
+
 complete_type(::Type{<:Function}) = "function"
 complete_type(::Type{<:Type}) = "type"
 complete_type(::Type{<:Tuple}) = "tuple"


### PR DESCRIPTION
This adds metadata to `complete_reply` to be displayed by JupyterLab. The implementation could propably be smarter and I'd happy to revise this based on comments. See: https://github.com/jupyterlab/jupyterlab/issues/3705 for info about the metadata.

![jupyter_completer](https://user-images.githubusercontent.com/430863/36726864-dcbb6566-1bc3-11e8-8b97-4416d73d68bb.png)
 

