### PR TITLE
Remove `"source" => "julia"` mapping

### DIFF
--- a/src/inline.jl
+++ b/src/inline.jl
@@ -40,7 +40,7 @@ for mime in ipy_mime
         function display(d::InlineDisplay, ::MIME{Symbol($mime)}, x)
             send_ipython(publish[],
                          msg_pub(execute_msg, "display_data",
-                                 Dict("source" => "julia", # optional
+                                 Dict(
                                   "metadata" => metadata(x), # optional
                                   "data" => Dict($mime => limitstringmime(MIME($mime), x)))))
         end


### PR DESCRIPTION
This does not seem to be supported in JupyterLab 0.31.  See [this link](https://github.com/sglyon/PlotlyJS.jl/issues/182#issue-300796032) for more detail.