### PR TITLE
Drop Julia v0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
   - 0.6
   - nightly
 matrix:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ the [NBInclude](https://github.com/stevengj/NBInclude.jl) package.)
 
 ## Installation
 
-First, [download Julia](http://julialang.org/downloads/) *version 0.4
+First, [download Julia](http://julialang.org/downloads/) *version 0.6
 or later* and run the installer.  Then run the Julia application
 (double-click on it); a window with a `julia>` prompt will appear.  At
 the prompt, type:
@@ -73,7 +73,7 @@ session instead of opening a new one.
 
 ```julia
 julia> using IJulia; notebook(detached=true)
-Process(`'C:\Users\JuliaUser\.julia\v0.4\Conda\deps\usr\Scripts\jupyter' notebook`, ProcessRunning)
+Process(`'C:\Users\JuliaUser\.julia\v0.6\Conda\deps\usr\Scripts\jupyter' notebook`, ProcessRunning)
 
 julia>
 ```
@@ -267,9 +267,9 @@ On Mac and Windows systems, it is currently easiest to use the
   you will need to install [PyQt4](http://www.riverbankcomputing.com/software/pyqt/download) or
   [PySide](http://qt-project.org/wiki/Category:LanguageBindings::PySide).
 
-* You need Julia version 0.4 or later.
+* You need Julia version 0.6 or later.
 
-Once IPython 3.0+ and Julia 0.4+ are installed, you can install IJulia from a Julia console by typing:
+Once IPython 3.0+ and Julia 0.6+ are installed, you can install IJulia from a Julia console by typing:
 ```julia
 Pkg.add("IJulia")
 ```
@@ -285,8 +285,8 @@ Most people will use the notebook (browser-based) interface, but you
 can also use the IPython
 [qtconsole](http://ipython.org/ipython-doc/dev/interactive/qtconsole.html)
 or IPython terminal interfaces by running `ipython qtconsole --kernel
-julia-0.4` or `ipython console --kernel julia-0.4`, respectively.
-(Replace `0.4` with whatever major Julia version you are using.)
+julia-0.6` or `ipython console --kernel julia-0.6`, respectively.
+(Replace `0.6` with whatever major Julia version you are using.)
 
 ## Debugging IJulia problems
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.5
+julia 0.6
 MbedTLS 0.4.3
 JSON 0.5
 ZMQ 0.3.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,5 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"

--- a/src/magics.jl
+++ b/src/magics.jl
@@ -381,9 +381,7 @@ svg_magic_help(magic::AbstractString, args::AbstractString) = md"""
 
 writefile_magic_help(magic::AbstractString, args::AbstractString) = md"""
     The analogue of IPython's `%%writefile filename` is
-    `write("filename", In[IJulia.n])`.  (In Julia 0.4, you
-    will need to do `using Compat` first in order to have
-    access to Julia 0.5's `write(filename,...)` syntax.)
+    `write("filename", In[IJulia.n])`.
 
     (`IJulia.n` is the index of the current code cell.  Of
     course, you can also use `In[N]` for some other `N` to output


### PR DESCRIPTION
Per https://discourse.julialang.org/t/errors-for-git-pkg/9351 Julia v0.5 is no longer supported on Linux and package operations will not be possible. This PR just stops testing Julia v0.5 on Travis since those tests will otherwise permanently fail. 

Personally I would recommend just dropping v0.5 from REQUIRE entirely. 