### PR TITLE
Fix windows check in ipython.jl

### DIFF
--- a/deps/ipython.jl
+++ b/deps/ipython.jl
@@ -14,7 +14,7 @@ function find_ipython()
                     "ipython.bat",convert(VersionNumber, chomp(readall(`ipython.bat --version`)))
                 catch e4
                     error("IPython is required for IJulia, got errors\n",
-                          "   $e1\n   $e2\n   $e3" * (@windows ? "\n$e4\n" : "") )
+                          "   $e1\n   $e2\n   $e3" * (is_windows() ? "\n$e4\n" : "") )
                 end
             end
         end


### PR DESCRIPTION
This change is required to run in julia 0.6 replacing the @windows macro used in julia 0.5 and earlier