### PR TITLE
Add logging override for 0.7

### DIFF
--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -160,7 +160,7 @@ function send_stream(name::AbstractString)
         n = num_utf8_trailing(d)
         dextra = d[end-(n-1):end]
         resize!(d, length(d) - n)
-        s = String(d)
+        s = String(copy(d))
         if isvalid(String, s)
             write(buf, dextra) # assume that the rest of the string will be written later
             length(d) == 0 && return

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -27,10 +27,25 @@ Base.setup_stdio(io::IJuliaStdio, readable::Bool) = Base.setup_stdio(io.io.io, r
 
 for s in ("stdout", "stderr", "stdin")
     f = Symbol("redirect_", s)
-    S = QuoteNode(Symbol(isdefined(Base, :stdout) ? s : uppercase(s)))
+    Sq = QuoteNode(Symbol(uppercase(s)))
+    sq = QuoteNode(Symbol(s))
     @eval function Base.$f(io::IJuliaStdio)
         io[:jupyter_stream] != $s && throw(ArgumentError(string("expecting ", $s, " stream")))
-        Core.eval(Base, Expr(:(=), $S, io))
+        if isdefined(Base, :stdout)
+            # On Julia 0.7, we need to override the global logger as well
+            logger = Base.CoreLogging._global_logstate.logger
+
+            # Override logging if it's pointing at the default stderr
+            if logger.stream == Base.stderr
+                new_logstate = Base.CoreLogging.LogState(typeof(logger)(io, logger.min_level))
+                Core.eval(Base.CoreLogging, Expr(:(=), :(_global_logstate), new_logstate))
+            end
+
+            Core.eval(Base, Expr(:(=), $sq, io))
+        else
+            # On Julia 0.6-, the variables are called Base.STDIO, not Base.stdio
+            Core.eval(Base, Expr(:(=), $Sq, io))
+        end
         return io
     end
 end

--- a/test/stdio.jl
+++ b/test/stdio.jl
@@ -16,15 +16,19 @@ mktemp() do path, io
     @test_throws ArgumentError redirect_stdin(IJulia.IJuliaStdio(io, "stderr"))
 end
 
+# Helper function to strip out color codes from strings to make it easier to
+# compare output within tests that has been colorized
+function strip_colorization(s)
+    return replace(s, r"(\e\[\d+m)"m => "")
+end
+
 mktemp() do path, io
     redirect_stderr(IJulia.IJuliaStdio(io, "stderr")) do
         warn("warn")
     end
     flush(io)
     seek(io, 0)
-    captured = read(io, String)
-    @test (captured == "\e[1m\e[33mWARNING: \e[39m\e[22m\e[33mwarn\e[39m\n" ||
-           captured == "WARNING: warn\n")  # output will differ based on whether color is currently enabled
+    @test strip_colorization(read(io, String)) == "WARNING: warn\n"
 end
 
 mktemp() do path, io


### PR DESCRIPTION
0.7 has a new logging infrastructure, which saves the output stream (e.g. `Base.stderr`) within itself.  We need to override that if we want to receive things like `warn()` or `info()`.  This is not the most elegant way this could be done, but it does seem to work (and passes its own test suite on 0.7)