### PR TITLE
fix #682: using InteractiveUtils on 0.7

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -1,4 +1,5 @@
 import IJulia
+using IJulia.Compat.InteractiveUtils
 
 # workaround #60:
 if IJulia.Compat.Sys.isapple()


### PR DESCRIPTION
Thanks for the suggestion! I can confirm that this eliminates the deprecation warning on `0.7.0-beta2`.