### PR TITLE
Make ipy_mime variable more readable

### DIFF
--- a/src/inline.jl
+++ b/src/inline.jl
@@ -4,7 +4,19 @@ struct InlineDisplay <: Compat.AbstractDisplay end
 
 # supported MIME types for inline display in IPython, in descending order
 # of preference (descending "richness")
-const ipy_mime = [ "application/vnd.dataresource+json", "application/vnd.vegalite.v2+json", "application/vnd.vega.v3+json", "text/html", "text/latex", "image/svg+xml", "image/png", "image/jpeg", "text/plain", "text/markdown", "application/javascript" ]
+const ipy_mime = [
+    "application/vnd.dataresource+json",
+    "application/vnd.vegalite.v2+json",
+    "application/vnd.vega.v3+json",
+    "text/html",
+    "text/latex",
+    "image/svg+xml",
+    "image/png",
+    "image/jpeg",
+    "text/plain",
+    "text/markdown",
+    "application/javascript"
+]
 
 # need special handling for showing a string as a textmime
 # type, since in that case the string is assumed to be


### PR DESCRIPTION
A purely aesthetic code change. I was consulting this for JuliaDocs/Documenter.jl#764 and figured it might be helpful for other too to have this be a bit more readable. It seems it has just been growing over the years.