### PR TITLE
Fix shell mode for Julia 1.0

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -161,7 +161,7 @@ function execute_request(socket, msg)
 
     # "; ..." cells are interpreted as shell commands for run
     code = replace(code, r"^\s*;.*$" =>
-                   m -> string(replace(m, r"^\s*;", "Base.repl_cmd(`"),
+                   m -> string(replace(m, r"^\s*;" => "Base.repl_cmd(`"),
                                "`, ", stdout_name, ")"))
 
     # a cell beginning with "? ..." is interpreted as a help request


### PR DESCRIPTION
`replace(string::AbstractString, pat, r[, n::Integer=0])`
gets deprecated in Julia 0.7 and removed in Julia 1.0. The new signature is
`replace(s::AbstractString, pat=>r; [count::Integer])`.

Currently, IJulia prints a deprecation warning on 0.7 and throws an exception on 1.0 when trying to execute a command in shell mode:
```
; ls
```
```
KERNEL EXCEPTION
MethodError: no method matching replace(::SubString{String}, ::Regex, ::String)
Closest candidates are:
  replace(::AbstractString, !Matched::Pair; count) at strings/util.jl:482
  replace(::AbstractString, !Matched::Pair, !Matched::Pair) at set.jl:487
  replace(::Any, !Matched::Pair...; count) at set.jl:428
  ...

Stacktrace:
 [1] (::getfield(IJulia, Symbol("##33#34")))(::SubString{String}) at /home/robert/.julia/dev/IJulia/src/execute_request.jl:164
 [2] _replace(::Base.GenericIOBuffer{Array{UInt8,1}}, ::getfield(IJulia, Symbol("##33#34")), ::String, ::UnitRange{Int64}, ::Regex) at ./strings/util.jl:409
 [3] #replace#323(::Int64, ::Function, ::String, ::Pair{Regex,getfield(IJulia, Symbol("##33#34"))}) at ./strings/util.jl:435
 [4] replace at ./strings/util.jl:423 [inlined]
 [5] execute_request(::ZMQ.Socket, ::IJulia.Msg) at /home/robert/.julia/dev/IJulia/src/execute_request.jl:158
 [6] #invokelatest#1 at ./essentials.jl:686 [inlined]
 [7] invokelatest at ./essentials.jl:685 [inlined]
 [8] eventloop(::ZMQ.Socket) at /home/robert/.julia/dev/IJulia/src/eventloop.jl:8
 [9] (::getfield(IJulia, Symbol("##15#18")))() at ./task.jl:259
```