### PR TITLE
Check whether Revise is running at startup, and if so configure it

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -29,4 +29,10 @@ delete!(task_local_storage(),:SOURCE_PATH)
 # workaround JuliaLang/julia#6765
 Core.eval(Base, :(is_interactive = true))
 
+# check whether Revise is running and as needed configure it to run before every prompt
+if isdefined(Main, :Revise)
+    mode = get(ENV, "JULIA_REVISE", "auto")
+    mode == "auto" && IJulia.push_preexecute_hook(Main.Revise.revise)
+end
+
 IJulia.waitloop()


### PR DESCRIPTION
Revise checks whether IJulia is running in its `__init__` function,
and if so defines an appropriate `preexecute_hook`. This catches cases
where the user launches IJulia and then loads Revise with `using Revise`.

However, I believe most users of Revise who also use the REPL
configure it in their `.julia/config/startup.jl` script.
It appears that this script runs before IJulia is loaded, and
as a consequence Revise has no chance to detect whether it should
define the IJulia hook.

To make both work independent of load order, we therefore have to check
symmetrically: Revise checks for IJulia, and IJulia checks for Revise.

Fixes https://github.com/timholy/Revise.jl/issues/150