### PR TITLE
Move flush_all() out from @async (#693)

### DIFF
--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -17,13 +17,8 @@ function eventloop(socket)
                     send_ipython(publish[], msg_pub(execute_msg, "error", content))
                 end
             finally
-                # @async no longer implicitly captures local variables (see PR #618)
                 flush_all()
-                let msg = msg
-                    @async begin
-                        send_status("idle", msg)
-                    end
-                end
+                send_status("idle", msg)
             end
         end
     catch e

--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -18,9 +18,9 @@ function eventloop(socket)
                 end
             finally
                 # @async no longer implicitly captures local variables (see PR #618)
+                flush_all()
                 let msg = msg
                     @async begin
-                        flush_all()
                         send_status("idle", msg)
                     end
                 end


### PR DESCRIPTION
This pull request fixes (probably not) #693 

I think this problem should be related to #491 and #563. Previously there's an issue about when to send the idle message. At that time, the solution was adding a delay before sending the idle message. I think it's because of the delay, the code, together with flush_all(), was wrapped by @asnyc. That means the flush_all() won't be called right after message handler finish the jobs. I think that will cause unexpected flush for the following messages. So I move the flush_all() out from the @asnyc wrapping and remain everything being the same (also remove @vprintln I just added). Then everything looks fine. It works with IJULIA_DEBUG is either true or false.

And according to #563, the delay is no more needed and has been removed. I think the @async is also not needed. But I'm not sure about this so I keep it in the code.