### PR TITLE
fixed read me file for updated `Pkg` keyword use

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ or later* and run the installer.  Then run the Julia application
 (double-click on it); a window with a `julia>` prompt will appear.  At
 the prompt, type:
 ```julia
+using Pkg
 Pkg.add("IJulia")
 ```
 to install IJulia.


### PR DESCRIPTION
`Pkg.*` keywords don't work without importing 'Pkg'. Updated read-me so that there's no confusion.