### PR TITLE
default to soft global scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,14 @@ IJulia.set_max_stdio(1 << 20)
 The module that code in an input cell is evaluated in can be set using `Main.IJulia.set_current_module(::Module)`.
 It defaults to `Main`.
 
+### Opting out of soft scope
+
+By default, IJulia evaluates user code using "soft" global scope, via the [SoftGlobalScope.jl package](https://github.com/stevengj/SoftGlobalScope.jl): this means that you don't need explicit `global` declarations to modify global variables in `for` loops and similar, which is convenient for interactive use.
+
+To opt out of this behavior, making notebooks behave similarly to global code in Julia `.jl` files,
+you can set `IJulia.SOFTSCOPE[] = false` at runtime, or include the environment variable `IJULIA_SOFTSCOPE=no`
+environment of the IJulia kernel when it is launched.
+
 ## Low-level Information
 
 ### Using older IPython versions

--- a/REQUIRE
+++ b/REQUIRE
@@ -4,3 +4,4 @@ JSON 0.17
 ZMQ 0.6.0
 Compat 0.69.0
 Conda 0.1.5
+SoftGlobalScope

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -35,7 +35,7 @@ The `IJulia` module is used in three ways:
 module IJulia
 export notebook, installkernel
 
-using ZMQ, JSON, Compat
+using ZMQ, JSON, Compat, SoftGlobalScope
 import Compat.invokelatest
 using Compat.Unicode: uppercase, lowercase
 import Compat.Dates

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -98,7 +98,9 @@ showerror_nobt(io, e, bt) = showerror(io, e, bt, backtrace=false)
 end
 
 # return the content of a pyerr message for exception e
-function error_content(e, bt=catch_backtrace(); backtrace_top::Symbol=:include_string, msg::AbstractString="")
+function error_content(e, bt=catch_backtrace();
+                       backtrace_top::Symbol=SOFTSCOPE[] ? :softscope_include_string : :include_string,
+                       msg::AbstractString="")
     tb = map(x->String(x), split(sprint(show_bt,
                                         backtrace_top,
                                         bt, 1:typemax(Int)),
@@ -189,6 +191,7 @@ function execute_request(socket, msg)
         else
             #run the code!
             occursin(magics_regex, code) ? magics_help(code) :
+                SOFTSCOPE[] ? softscope_include_string(current_module[], code, "In[$n]") :
                 include_string(current_module[], code, "In[$n]")
         end
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -24,11 +24,13 @@ end
 const orig_stdin  = Ref{IO}()
 const orig_stdout = Ref{IO}()
 const orig_stderr = Ref{IO}()
+const SOFTSCOPE = Ref{Bool}()
 function __init__()
     seed!(IJulia_RNG)
     orig_stdin[]  = stdin
     orig_stdout[] = stdout
     orig_stderr[] = stderr
+    SOFTSCOPE[] = lowercase(get(ENV, "IJULIA_SOFTSCOPE", "yes")) in ("yes", "true")
 end
 
 # the following constants need to be initialized in init().


### PR DESCRIPTION
Defaults to "soft" global scope rules, as discussed in JuliaLang/julia#28789, to make it easier to write interactive code.  For example, the code
```jl
s = 0
for i = 1:10
    s += i
end
s
```
requires a `global` keyword in the `for` loop in Julia 1.0, but in IJulia this can be omitted.  Requires the [SoftGlobalScope package](https://github.com/stevengj/SoftGlobalScope.jl).

(The README gives opt-out instructions.)