### PR TITLE
Do not require IJulia to run or be installed in the default environment.

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -1,3 +1,8 @@
+if "IJuliaProjectPath" in keys(ENV)
+    using Pkg
+    Pkg.activate(ENV["IJuliaProjectPath"])
+end
+
 import IJulia
 using IJulia.Compat.InteractiveUtils
 


### PR DESCRIPTION
Currently IJulia needs to be installed in the default environment, (the one active after startup.jl) or the kernel will quietly die with IJupiter only saying that it cannot connect to the kernel.

This PR allows to set the Project in which the IJulia kernel is run through an environment variable.
IJulia needs to have been installed in that Project of course.

I will add the needed documentation if this PR is in principle approved. Note that it may get superseded by whatever #673 results in.