### PR TITLE
Display the banner of Julia in the console ☺

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -21,6 +21,8 @@ ENV["LINES"] = get(ENV, "LINES", 30)
 ENV["COLUMNS"] = get(ENV, "COLUMNS", 80)
 
 println(IJulia.orig_stdout[], "Starting kernel event loops.")
+# display the cute banner of Julia in the console
+Base.banner(IJulia.orig_stdout[])
 IJulia.watch_stdio()
 
 # workaround JuliaLang/julia#4259


### PR DESCRIPTION
Not a great enhancement, but I wanted to see the julia banner when I used Julia in jupyter-console (because vim mode is not anymore supported since they remove readline).
