### PR TITLE
Tell the user to install the jupyter-client package on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ private to Julia (not in your `PATH`).  (You can use `using IJulia` followed by
 `IJulia.jupyter` to find the location `jupyter` where was installed.)
 On Linux, it defaults to looking for `jupyter` in your `PATH` first,
 and only installs the Conda Jupyter if that fails; you can force
-it to use Conda on Linux by setting `ENV["JUPYTER"]=""` first (see below).
+it to use Conda on Linux by setting `ENV["JUPYTER"]=""` first (see below). In a Debian or Ubuntu 
+Linux system, install the package jupyter-client.
 
 Alternatively, you can [install
 Jupyter](http://jupyter.readthedocs.org/en/latest/install.html) (or


### PR DESCRIPTION
This help me to fix an installation problem for IJulia on Debian. So I think this could be useful for other users, and I suggest to add this to the documentation in the Readme file.