### PR TITLE
store prefs in depot_path/prefs

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -26,7 +26,7 @@ function prog_version(prog)
     end
 end
     
-const prefsfile = joinpath(first(DEPOT_PATH), "prefs", "IJulia")
+prefsfile = joinpath(first(DEPOT_PATH), "prefs", "IJulia")
 mkpath(dirname(prefsfile))
 
 global jupyter = get(ENV, "JUPYTER", isfile(prefsfile) ? readchomp(prefsfile) : Compat.Sys.isunix() && !Compat.Sys.isapple() ? "jupyter" : "")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -25,8 +25,11 @@ function prog_version(prog)
         return v"0.0"
     end
 end
+    
+const prefsfile = joinpath(first(DEPOT_PATH), "prefs", "IJulia")
+mkpath(dirname(prefsfile))
 
-global jupyter = get(ENV, "JUPYTER", isfile("JUPYTER") ? readchomp("JUPYTER") : Compat.Sys.isunix() && !Compat.Sys.isapple() ? "jupyter" : "")
+global jupyter = get(ENV, "JUPYTER", isfile(prefsfile) ? readchomp(prefsfile) : Compat.Sys.isunix() && !Compat.Sys.isapple() ? "jupyter" : "")
 if isempty(jupyter)
     jupyter_vers = nothing
 else
@@ -117,7 +120,7 @@ deps = """
 if !isfile("deps.jl") || read("deps.jl", String) != deps
     write("deps.jl", deps)
 end
-write("JUPYTER", jupyter)
+write(prefsfile, jupyter)
 
 #######################################################################
 catch


### PR DESCRIPTION
As a stopgap until we get proper package options (JuliaLang/Juleps#38), store JUPYTER preference in depot_path/prefs/IJulia so that it isn't forgotten when IJulia is updated.  See also JuliaPy/PyCall.jl#589