### PR TITLE
Jupyter lab

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -98,6 +98,11 @@ notebook = kspec_cmd.exec
 n = notebook[end]
 ki = findlast("kernelspec", n)
 notebook[end] = n[1:prevind(n,first(ki))] * "notebook" * n[nextind(n,last(ki)):end]
+    
+#######################################################################
+# create command to launch jupyterlab
+labbook=deepcopy(notebook)
+labbook[end] = n[1:prevind(n,first(ki))] * "lab" * n[nextind(n,last(ki)):end]
 
 #######################################################################
 # make it easier to get more debugging output by setting JULIA_DEBUG=1
@@ -111,10 +116,12 @@ IJULIA_DEBUG = IJULIA_DEBUG in ("1", "true", "yes")
 if v"4.2" ≤ jupyter_vers < v"5.1"
     # disable broken data-rate limit (issue #528)
     push!(notebook, "--NotebookApp.iopub_data_rate_limit=2147483647")
+    push!(labbook, "--NotebookApp.iopub_data_rate_limit=2147483647")
 end
 deps = """
     const jupyter = "$(escape_string(jupyter))"
     const notebook_cmd = ["$(join(map(escape_string, notebook), "\", \""))"]
+    const labbook_cmd = ["$(join(map(escape_string, labbook), "\", \""))"]
     const jupyter_vers = $(repr(jupyter_vers))
     const IJULIA_DEBUG = $(IJULIA_DEBUG)
     """

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -46,6 +46,7 @@ if Sys.ARCH in (:i686, :x86_64) && (jupyter_vers === nothing || jupyter_vers < v
     isconda || jupyter_vers === nothing || Compat.@info("$jupyter was too old: got $jupyter_vers, required ≥ 3.0")
     Compat.@info("Installing Jupyter via the Conda package.")
     Conda.add("jupyter")
+    Conda.add("jupyterlab")
     jupyter = abspath(Conda.SCRIPTDIR, "jupyter")
     jupyter_vers = prog_version(jupyter)
 end

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -111,37 +111,21 @@ stop Jupyter will then be to kill it in your operating system's
 process manager.)
 """
 function notebook(; dir=homedir(), detached=false)
-    inited && error("IJulia is already running")
-    if Sys.isapple() # issue #551 workaround, remove after macOS 10.12.6 release?
-        withenv("BROWSER"=>"open") do
-            p = run(Cmd(`$notebook_cmd`, detach=true, dir=dir); wait=false)
-        end
-    else
-        p = run(Cmd(`$notebook_cmd`, detach=true, dir=dir); wait=false)
-    end
-    if !detached
-        try
-            wait(p)
-        catch e
-            if isa(e, InterruptException)
-                kill(p, 2) # SIGINT
-            else
-                kill(p) # SIGTERM
-                rethrow()
-            end
-        end
-    end
-    return p
+    launch(notebook_cmd,dir,detached)
 end
 
 function labbook(; dir=homedir(), detached=false)
+    launch(labbook_cmd,dir,detached)
+end
+
+function launch(launch_cmd, dir=homedir(), detached=false)
     inited && error("IJulia is already running")
     if Sys.isapple() # issue #551 workaround, remove after macOS 10.12.6 release?
         withenv("BROWSER"=>"open") do
-            p = run(Cmd(`$labbook_cmd`, detach=true, dir=dir); wait=false)
+            p = run(Cmd(`$launch_cmd`, detach=true, dir=dir); wait=false)
         end
     else
-        p = run(Cmd(`$labbook_cmd`, detach=true, dir=dir); wait=false)
+        p = run(Cmd(`$launch_cmd`, detach=true, dir=dir); wait=false)
     end
     if !detached
         try

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -138,10 +138,10 @@ function labbook(; dir=homedir(), detached=false)
     inited && error("IJulia is already running")
     if Sys.isapple() # issue #551 workaround, remove after macOS 10.12.6 release?
         withenv("BROWSER"=>"open") do
-            p = run(Cmd(`$jlab_cmd`, detach=true, dir=dir); wait=false)
+            p = run(Cmd(`$labbook_cmd`, detach=true, dir=dir); wait=false)
         end
     else
-        p = run(Cmd(`$jlab_cmd`, detach=true, dir=dir); wait=false)
+        p = run(Cmd(`$labbook_cmd`, detach=true, dir=dir); wait=false)
     end
     if !detached
         try


### PR DESCRIPTION
Adds JupyterLab installation alongside the installation of Jupyter.
Add `labbook()` command which launches IJulia in Jupyter Lab rather than in the standard Jupyter notebook. (`notebook()` function is unchanged and behaves as before). This function works by the addition of a launch command to the deps.jl file.

This is a first attempt to close #666 by integrating JupyterLab simply.