### PR TITLE
Implement message interrupt mode

### DIFF
--- a/deps/kspec.jl
+++ b/deps/kspec.jl
@@ -83,6 +83,8 @@ function installkernel(name::AbstractString, julia_options::AbstractString...;
             "display_name" => name * " " * Base.VERSION_STRING * debugdesc,
             "language" => "julia",
             "env" => env,
+            # Jupyter's signal interrupt mode is not supported on Windows
+            "interrupt_mode" => Sys.iswindows() ? "message" : "signal",
         )
 
         mkpath(juliakspec)

--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -32,16 +32,17 @@ function eventloop(socket)
     end
 end
 
+const requests_task = Ref{Task}()
 function waitloop()
     @async eventloop(control[])
-    requests_task = @async eventloop(requests[])
+    requests_task[] = @async eventloop(requests[])
     while true
         try
             wait()
         catch e
             # send interrupts (user SIGINT) to the code-execution task
             if isa(e, InterruptException)
-                @async Base.throwto(requests_task, e)
+                @async Base.throwto(requests_task[], e)
             else
                 rethrow()
             end

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -261,6 +261,11 @@ function is_complete_request(socket, msg)
                            Dict("status"=>status, "indent"=>"")))
 end
 
+function interrupt_request(socket, msg)
+    @async Base.throwto(requests_task[], InterruptException())
+    send_ipython(requests[], msg_reply(msg, "interrupt_reply", Dict()))
+end
+
 const handlers = Dict{String,Function}(
     "execute_request" => execute_request,
     "complete_request" => complete_request,
@@ -270,6 +275,7 @@ const handlers = Dict{String,Function}(
     "shutdown_request" => shutdown_request,
     "history_request" => history_request,
     "is_complete_request" => is_complete_request,
+    "interrupt_request" => interrupt_request,
     "comm_open" => comm_open,
     "comm_info_request" => comm_info_request,
     "comm_msg" => comm_msg,

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -20,7 +20,7 @@ msg_header(m::Msg, msg_type::String) = Dict("msg_id" => uuid4(),
                                             "session" => m.header["session"],
                                             "date" => now(),
                                             "msg_type" => msg_type,
-                                            "version" => "5.0")
+                                            "version" => "5.3")
 
 # PUB/broadcast messages use the msg_type as the ident, except for
 # stream messages which use the stream name (e.g. "stdout").


### PR DESCRIPTION
Fixes #503.

This switches entirely over to message mode. We can either make this configurable (though it must be set for Windows) or remove the signal mode completely.

/EDIT: After adjusting to the PR comments, message mode is only used on Windows.