### PR TITLE
Move mode and startup global variable into let block

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -43,8 +43,9 @@ Core.eval(Base, :(is_interactive = true))
 
 # check whether Revise is running and as needed configure it to run before every prompt
 if isdefined(Main, :Revise)
-    mode = get(ENV, "JULIA_REVISE", "auto")
-    mode == "auto" && IJulia.push_preexecute_hook(Main.Revise.revise)
+    let mode = get(ENV, "JULIA_REVISE", "auto")
+        mode == "auto" && IJulia.push_preexecute_hook(Main.Revise.revise)
+    end
 end
 
 IJulia.waitloop()

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -17,8 +17,9 @@ end
 
 IJulia.init(ARGS)
 
-startupfile = abspath(homedir(), ".julia", "config", "startup_ijulia.jl")
-isfile(startupfile) && Base.JLOptions().startupfile != 2 && Base.include(Main, startupfile)
+let startupfile = abspath(homedir(), ".julia", "config", "startup_ijulia.jl")
+    isfile(startupfile) && Base.JLOptions().startupfile != 2 && Base.include(Main, startupfile)
+end
 
 # import things that we want visible in IJulia but not in REPL's using IJulia
 import IJulia: ans, In, Out, clear_history


### PR DESCRIPTION
Otherwise the name `mode` is used in the julia session that runs in a notebook. This is especially weird when one then does `using Distributions`, because message appears that `mode` is already defined in `Main`.