### PR TITLE
Set JULIA_PROJECT="@." for kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,17 @@ running IJulia kernel.
 If your code needs to detect whether it is running in an IJulia notebook
 (or other Jupyter client), it can check `isdefined(Main, :IJulia) && Main.IJulia.inited`.
 
+### Julia projects
+
+The default Jupyter kernel that is installed by IJulia starts with the
+Julia command line flag `--project=@.`. A  `Project.toml` (or `JuliaProject.toml`)
+in the folder of a notebook (or in a parent folder of this notebook) will
+therefore automatically become the active project for that notebook.
+Users that don't want this behavior should install an additional IJulia
+kernel without that command line flag (see section
+[Installing additional Julia kernels](#Installing-additional-Julia-kernels)).
+
+
 ### Customizing your IJulia environment
 
 If you want to run code every time you start IJulia---but only when in IJulia---add a `startup_ijulia.jl` file to your Julia `config` directory, e.g., `~/.julia/config/startup_ijulia.jl`.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using Conda
 
 # Install Jupyter kernel-spec file.
 include("kspec.jl")
-kernelpath = installkernel("Julia", env=Dict("JULIA_PROJECT"=>"@."))
+kernelpath = installkernel("Julia", "--project=@.")
 
 # make it easier to get more debugging output by setting JULIA_DEBUG=1
 # when building.

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,7 +2,7 @@ using Conda
 
 # Install Jupyter kernel-spec file.
 include("kspec.jl")
-kernelpath = installkernel("Julia")
+kernelpath = installkernel("Julia", env=Dict("JULIA_PROJECT"=>"@."))
 
 # make it easier to get more debugging output by setting JULIA_DEBUG=1
 # when building.


### PR DESCRIPTION
This is one way to handle https://github.com/JuliaLang/IJulia.jl/issues/750.

What this would do is that whenever you open a notebook, if there is a `Project.toml` in the folder of the notebook, or in one of its parent folders, that environment will be the active environment for the kernel of that notebook.

My understanding right now is that we are not going to somehow embed env info in the notebook itself, so this might be the next best thing to get around these annoying `using Pkg; pkg"activate ."` that one needs now at the top of each notebook if one is using environments.

This issue came up in the context of binder and https://github.com/jupyter/repo2docker/pull/612.

Pinging a couple of folks that I think should opine on this: @StefanKarpinski, @KristofferC and @stevengj.