### PR TITLE
fix(vega): add v4 mime type

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -35,7 +35,7 @@ This is necessary to embed the JSON as is in the displaydata bundle (rather than
 as stringify'd JSON).
 """
 const ijulia_jsonmime_types = Vector{Union{MIME, Vector{MIME}}}([
-    [MIME("application/vnd.vegalite.v2+json"), MIME("application/vnd.vega.v3+json")],
+    [MIME("application/vnd.vegalite.v2+json"), MIME("application/vnd.vega.v4+json"), MIME("application/vnd.vega.v3+json")],
     MIME("application/vnd.dataresource+json"), MIME("application/vnd.plotly.v1+json")
 ])
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -35,7 +35,8 @@ This is necessary to embed the JSON as is in the displaydata bundle (rather than
 as stringify'd JSON).
 """
 const ijulia_jsonmime_types = Vector{Union{MIME, Vector{MIME}}}([
-    [MIME("application/vnd.vegalite.v2+json"), MIME("application/vnd.vega.v4+json"), MIME("application/vnd.vega.v3+json")],
+    [[MIME("application/vnd.vegalite.v$n+json") for n in 3:-1:2]...,
+    [MIME("application/vnd.vega.v$n+json") for n in 5:-1:3]...],
     MIME("application/vnd.dataresource+json"), MIME("application/vnd.plotly.v1+json")
 ])
 

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -7,6 +7,7 @@ struct InlineDisplay <: AbstractDisplay end
 const ipy_mime = [
     "application/vnd.dataresource+json",
     "application/vnd.vegalite.v2+json",
+    "application/vnd.vega.v4+json",
     "application/vnd.vega.v3+json",
     "application/vnd.plotly.v1+json",
     "text/html",

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -6,9 +6,8 @@ struct InlineDisplay <: AbstractDisplay end
 # of preference (descending "richness")
 const ipy_mime = [
     "application/vnd.dataresource+json",
-    "application/vnd.vegalite.v2+json",
-    "application/vnd.vega.v4+json",
-    "application/vnd.vega.v3+json",
+    ["application/vnd.vegalite.v$n+json" for n in 3:-1:2]...,
+    ["application/vnd.vega.v$n+json" for n in 5:-1:3]...,
     "application/vnd.plotly.v1+json",
     "text/html",
     "text/latex",


### PR DESCRIPTION
The v4 mime type is what is currently supported out of the box by Jupyter, v3 requires an extension to be installed.

This PR adds the v4 mime type to the lists of supported mime types.  MIME"application/vnd.vega.v3+json" was left for backwards compatibility.  Vega recently released v5, so I expect this will need to be updated again in the near future.

I am concurrently putting in a PR for [VegaLite.jl](https://github.com/fredo-dedup/VegaLite.jl) to update the mime type on that end too.