### PR TITLE
Fix `IJulia not found` when installed, but not in user's Environment

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -1,3 +1,7 @@
+# Manually add this package as the last entry in the LOAD_PATH so that if IJulia isn't
+# installed in the user's Environment, IJulia will still be picked up from this directory.
+push!(LOAD_PATH, dirname(@__DIR__))
+
 import IJulia
 
 let


### PR DESCRIPTION
Add the IJulia package that contains kernel.jl as last element of `LOAD_PATH`.  If IJulia isn't found in the user's environment, this will then default to loading the version of IJulia that the kernel.jl was installed from.

This most commonly occurs when the user has installed IJulia in a custom environment, but not the top-level shared environment.
This is a fix for the issue discussed here: https://github.com/JuliaLang/IJulia.jl/pull/820#issuecomment-482839448



