### PR TITLE
Remove minor version number from kernel name (currently e.g. "julia-1.1")

### DIFF
--- a/deps/kspec.jl
+++ b/deps/kspec.jl
@@ -38,7 +38,7 @@ kerneldir() = joinpath(jupyter_data_dir(), "kernels")
 
 
 exe(s::AbstractString) = Sys.iswindows() ? "$s.exe" : s
- 
+
 """
     installkernel(name::AbstractString, options::AbstractString...;
                   specname::AbstractString,
@@ -68,7 +68,7 @@ function installkernel(name::AbstractString, julia_options::AbstractString...;
     debugdesc = ccall(:jl_is_debugbuild,Cint,())==1 ? "-debug" : ""
 
     # path of the Jupyter kernelspec directory to install
-    juliakspec = joinpath(kerneldir(), "$specname-$(VERSION.major).$(VERSION.minor)$debugdesc")
+    juliakspec = joinpath(kerneldir(), "$specname$(VERSION.major)$debugdesc")
     @info("Installing $name kernelspec in $juliakspec")
     rm(juliakspec, force=true, recursive=true)
     try

--- a/deps/kspec.jl
+++ b/deps/kspec.jl
@@ -68,7 +68,7 @@ function installkernel(name::AbstractString, julia_options::AbstractString...;
     debugdesc = ccall(:jl_is_debugbuild,Cint,())==1 ? "-debug" : ""
 
     # path of the Jupyter kernelspec directory to install
-    juliakspec = joinpath(kerneldir(), "$specname$(VERSION.major)$debugdesc")
+    juliakspec = joinpath(kerneldir(), "$specname-v$(VERSION.major)$debugdesc")
     @info("Installing $name kernelspec in $juliakspec")
     rm(juliakspec, force=true, recursive=true)
     try

--- a/test/install.jl
+++ b/test/install.jl
@@ -1,6 +1,7 @@
 using Test
 import IJulia, JSON
 
+isdebug() = ccall(:jl_is_debugbuild,Cint,())==1
 @testset "installkernel" begin
     let kspec = IJulia.installkernel("ijuliatest", "-O3", "-p2",
                     env=Dict("FOO"=>"yes"), specname="Yef1rLr4kXKxq9rbEh3m")
@@ -10,12 +11,31 @@ import IJulia, JSON
             @test isfile(joinpath(kspec, "logo-32x32.png"))
             @test isfile(joinpath(kspec, "logo-64x64.png"))
             let k = open(JSON.parse, joinpath(kspec, "kernel.json"))
-                debugdesc = ccall(:jl_is_debugbuild,Cint,())==1 ? "-debug" : ""
+                debugdesc = isdebug() ? "-debug" : ""
                 @test k["display_name"] == "ijuliatest" * " " * Base.VERSION_STRING * debugdesc
                 @test k["argv"][end] == "{connection_file}"
                 @test k["argv"][end-3:end-2] == ["-O3", "-p2"]
                 @test k["language"] == "julia"
                 @test k["env"]["FOO"] == "yes"
+            end
+        finally
+            rm(kspec, force=true, recursive=true)
+        end
+    end
+end
+@testset "installkernel -- custom names" begin
+    let kspec = IJulia.installkernel("ijuliatest", "-O3", "-p2",
+                    env=Dict("FOO"=>"yes"),
+                    specname="Yef1rLr4kXKxq9rbEh3m",
+                    specversion="v1",
+                    specdebugdesc=isdebug() ? "dbg" : "")
+        try
+            debugdesc = isdebug() ? "-dbg" : ""
+            @test dirname(kspec) == IJulia.kerneldir()
+            @test basename(kspec) == "Yef1rLr4kXKxq9rbEh3m-v1$debugdesc"
+            @test isfile(joinpath(kspec, "kernel.json"))
+            let k = open(JSON.parse, joinpath(kspec, "kernel.json"))
+                @test k["display_name"] == "ijuliatest" * " " * Base.VERSION_STRING * debugdesc
             end
         finally
             rm(kspec, force=true, recursive=true)


### PR DESCRIPTION
After the Julia 1.0 release, minor version changes are supposed to be
non-breaking, but before this commit, upgrading julia would break your
notebooks (in CI) since the kernel can't be found. ~This commit changes IJulia to
only use the major version number in the kernel name so that tests will
succeed b/w minor julia releases.~

EDIT: This PR adds options to set the `specversion` and `specdebugdesc` so that upgrading Julia version won't break automated CI tests for existing jupyter notebooks that expect a given kernel name.


---------------------


Fixes #852 