### PR TITLE
Fix #855, add required status field for JupyterLab 1.0

### DIFF
--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -168,7 +168,8 @@ function kernel_info_request(socket, msg)
                                                               "url"=>"http://docs.julialang.org/"),
                                                          Dict("text"=>"Julia Packages",
                                                               "url"=>"http://pkg.julialang.org/")
-                                                        ])))
+                                                        ],
+                                        "status" => "ok")))
 end
 
 function connect_request(socket, msg)


### PR DESCRIPTION
This PR adds a `status` field to `kernel_info_reply`. With this, syntax highlighting is working for me again in JupyterLab 1.0. Thanks to @krassowski for pointing out precisely what needed to be done!