### PR TITLE
Add `display_payload` function.

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -87,6 +87,9 @@ display_mimejson(m::MIME, x) = (m, JSON.JSONText(limitstringmime(m, x)))
 Generate a dictionary of `mime_type => data` pairs for all registered MIME
 types. This is the format that Jupyter expects in display_data and
 execute_result messages.
+
+This function may also return `nothing`, in which case no Jupyter message is
+sent at all.
 """
 function display_dict(x)
     data = Dict{String, Union{String, JSONText}}()
@@ -114,8 +117,23 @@ function display_dict(x)
     end
 
     return data
-
 end
+
+display_dict(::Nothing) = nothing
+
+"""
+Generate a `(data=..., metadata=...)` tuple.
+
+This defaults to using `display_dict` and `metadata` respectively (see the
+documentaiton for those functions to see what `data` and `metadata` should be).
+A custom method for this function can be specified whenever it is difficult to
+compute the data and metadata separately. Most users will just need to define a
+method for `display_dict`.
+
+This function may also return `nothing`, in which case no Jupyter message is
+sent at all.
+"""
+display_payload(x) = (data=display_dict(x), metadata=metadata(x))
 
 # queue of objects to display at end of cell execution
 const displayqueue = Any[]

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -107,16 +107,23 @@ function execute_request(socket, msg)
         undisplay(result) # dequeue if needed, since we display result in pyout
         invokelatest(display) # flush pending display requests
 
-        if result !== nothing
-            result_metadata = invokelatest(metadata, result)
-            result_data = invokelatest(display_dict, result)
-            send_ipython(publish[],
-                         msg_pub(msg, "execute_result",
-                                 Dict("execution_count" => n,
-                                              "metadata" => result_metadata,
-                                              "data" => result_data)))
-
+        result_payload = invokelatest(display_payload, result)
+        if result_payload !== nothing && result_payload[1] !== nothing
+            data, metadata = result_payload
+            send_ipython(
+                publish[],
+                msg_pub(
+                    msg,
+                    "execute_result",
+                    Dict(
+                        "execution_count" => n,
+                        "metadata" => metadata,
+                        "data" => data,
+                    ),
+                ),
+            )
         end
+
         send_ipython(requests[],
                      msg_reply(msg, "execute_reply",
                                Dict("status" => "ok",


### PR DESCRIPTION
This allows users (mostly package authors) to specify the data and metadata in the same method.

This is useful for my work on JuliaPy/PyInteract.jl#1 because we want to hook into the way that IPython generates the display information, but IPython works by returning a tuple (so to generate both we'd have to call the IPython formatter twice which is less than ideal).

Constructive criticism gladly encouraged. :^)

Ping @stevengj.