### PR TITLE
Add InlineIOContext with Jupyter property.

### DIFF
--- a/src/inline.jl
+++ b/src/inline.jl
@@ -26,6 +26,12 @@ israwtext(::MIME, x::AbstractString) = true
 israwtext(::MIME"text/plain", x::AbstractString) = false
 israwtext(::MIME, x) = false
 
+InlineIOContext(io, KVs::Pair...) = IOContext(
+    io,
+    :limit=>true, :color=>true, :jupyter=>true,
+    KVs...
+)
+
 # convert x to a string of type mime, making sure to use an
 # IOContext that tells the underlying show function to limit output
 function limitstringmime(mime::MIME, x)
@@ -34,14 +40,14 @@ function limitstringmime(mime::MIME, x)
         if israwtext(mime, x)
             return String(x)
         else
-            show(IOContext(buf, :limit=>true, :color=>true), mime, x)
+            show(InlineIOContext(buf), mime, x)
         end
     else
         b64 = Base64EncodePipe(buf)
         if isa(x, Vector{UInt8})
             write(b64, x) # x assumed to be raw binary data
         else
-            show(IOContext(b64, :limit=>true, :color=>true), mime, x)
+            show(InlineIOContext(b64), mime, x)
         end
         close(b64)
     end

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -1,0 +1,25 @@
+using Test
+import IJulia: InlineIOContext
+
+@testset "Custom Jupyter inline display" begin
+    struct TestDataType
+        payload
+    end
+
+    function Base.show(io::IO, m::MIME"text/plain", data::TestDataType)
+        print(io, "TestDataType: ")
+        if get(io, :jupyter, false)
+            print(io, "Jupyter: ")
+        end
+        Base.show(io, m, data.payload)
+    end
+
+    data = TestDataType("foo")
+    buf = IOBuffer()
+
+    Base.show(buf, MIME("text/plain"), data)
+    @test String(take!(buf)) == "TestDataType: \"foo\""
+
+    Base.show(InlineIOContext(buf), MIME("text/plain"), data)
+    @test String(take!(buf)) == "TestDataType: Jupyter: \"foo\""
+end

--- a/test/inline.jl
+++ b/test/inline.jl
@@ -2,7 +2,7 @@ using Test
 import IJulia: InlineIOContext
 
 @testset "Custom Jupyter inline display" begin
-    struct TestDataType
+    @eval struct TestDataType
         payload
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,9 @@
-for file in ["install.jl","comm.jl", "msg.jl", "execute_request.jl", "stdio.jl"]
+const TEST_FILES = [
+    "install.jl", "comm.jl", "msg.jl", "execute_request.jl", "stdio.jl",
+    "inline.jl",
+]
+
+for file in TEST_FILES
     println(file)
     include(file)
 end


### PR DESCRIPTION
Adds a special property to the `IOContext` used when displaying data (as well as a helper function to create aforementioned `IOContext`).

My use case for this is wanting to avoid double-serializing things when using Jupyter and WebIO. I want to be able to detect that we're using IJulia to display and therefore not render the full HTML structure (which is actually rendered using a custom JSON MIME type).

Included test case for usage.