### PR TITLE
Add support for vega-lite 4 MIME type

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -35,7 +35,7 @@ This is necessary to embed the JSON as is in the displaydata bundle (rather than
 as stringify'd JSON).
 """
 const ijulia_jsonmime_types = Vector{Union{MIME, Vector{MIME}}}([
-    [[MIME("application/vnd.vegalite.v$n+json") for n in 3:-1:2]...,
+    [[MIME("application/vnd.vegalite.v$n+json") for n in 4:-1:2]...,
     [MIME("application/vnd.vega.v$n+json") for n in 5:-1:3]...],
     MIME("application/vnd.dataresource+json"), MIME("application/vnd.plotly.v1+json")
 ])

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -6,7 +6,7 @@ struct InlineDisplay <: AbstractDisplay end
 # of preference (descending "richness")
 const ipy_mime = [
     "application/vnd.dataresource+json",
-    ["application/vnd.vegalite.v$n+json" for n in 3:-1:2]...,
+    ["application/vnd.vegalite.v$n+json" for n in 4:-1:2]...,
     ["application/vnd.vega.v$n+json" for n in 5:-1:3]...,
     "application/vnd.plotly.v1+json",
     "text/html",


### PR DESCRIPTION
I think those are the only two places I need to adjust, right? Would be great if a new version with this could be released once it is merged.