### PR TITLE
TagBot: use DOCUMENTER_KEY

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -2,6 +2,7 @@ name: TagBot
 on:
   schedule:
     - cron: 0 0 * * *
+  workflow_dispatch:
 jobs:
   TagBot:
     runs-on: ubuntu-latest
@@ -9,3 +10,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This will ensure that, after the next release is registered, that the tag will correctly build the documentation.

Once the documentation has been built on a tag, the "stable" link will work.

cc: @stevengj 