### PR TITLE
Organize/add docstrings in API docs

### DIFF
--- a/docs/src/library/internals.md
+++ b/docs/src/library/internals.md
@@ -1,6 +1,12 @@
 # Internals
 
 
+## Initialization
+
+```@docs
+IJulia.init
+```
+
 
 ## Cell execution hooks
 
@@ -17,14 +23,45 @@ IJulia.push_preexecute_hook
 ## Messaging
 
 ```@docs
+IJulia.Msg
+IJulia.msg_header
+IJulia.send_ipython
+IJulia.recv_ipython
 IJulia.set_cur_msg
+IJulia.send_status
+```
+
+
+## Request handlers
+
+```@docs
+IJulia.handlers
+IJulia.connect_request
+IJulia.execute_request
+IJulia.shutdown_request
+IJulia.interrupt_request
+IJulia.inspect_request
+IJulia.history_request
+IJulia.complete_request
+IJulia.kernel_info_request
+IJulia.is_complete_request
+```
+
+
+## Event loop
+
+```@docs
+IJulia.eventloop
+IJulia.waitloop
 ```
 
 
 ## IO
 
 ```@docs
+IJulia.IJuliaStdio
 IJulia.capture_stdout
+IJulia.capture_stderr
 IJulia.watch_stream
 ```
 
@@ -32,11 +69,26 @@ IJulia.watch_stream
 ## Multimedia display
 
 ```@docs
-IJulia.ijulia_jsonmime_types
+IJulia.InlineDisplay
+IJulia.InlineIOContext
+IJulia.ipy_mime
 IJulia.ijulia_mime_types
+IJulia.ijulia_jsonmime_types
+IJulia.limitstringmime
+IJulia.israwtext
 IJulia.display_dict
 IJulia.display_mimejson
 IJulia.display_mimestring
+IJulia.register_mime
+IJulia.register_jsonmime
+```
+
+
+## Jupyter
+
+```@docs
+IJulia.find_jupyter_subcommand
+IJulia.launch
 ```
 
 

--- a/docs/src/library/internals.md
+++ b/docs/src/library/internals.md
@@ -1,3 +1,54 @@
 # Internals
 
-TODO
+
+
+## Cell execution hooks
+
+```@docs
+IJulia.pop_posterror_hook
+IJulia.pop_postexecute_hook
+IJulia.pop_preexecute_hook
+IJulia.push_posterror_hook
+IJulia.push_postexecute_hook
+IJulia.push_preexecute_hook
+```
+
+
+## Messaging
+
+```@docs
+IJulia.set_cur_msg
+```
+
+
+## IO
+
+```@docs
+IJulia.capture_stdout
+IJulia.watch_stream
+```
+
+
+## Multimedia display
+
+```@docs
+IJulia.ijulia_jsonmime_types
+IJulia.ijulia_mime_types
+IJulia.display_dict
+IJulia.display_mimejson
+IJulia.display_mimestring
+```
+
+
+## Debugging
+
+```@docs
+IJulia.set_verbose
+```
+
+
+## Utility
+
+```@docs
+IJulia.num_utf8_trailing
+```

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -1,6 +1,47 @@
 # Public API
 
 
-```@autodocs
-Modules = [ IJulia ]
+## General
+
+```@docs
+IJulia.IJulia
+IJulia.inited
+IJulia.installkernel
+```
+
+
+## Launching the server
+
+```@docs
+IJulia.jupyterlab
+IJulia.notebook
+```
+
+
+## History
+
+```@docs
+IJulia.In
+IJulia.Out
+IJulia.ans
+IJulia.n
+IJulia.clear_history
+IJulia.history
+```
+
+
+## Cells
+
+```@docs
+IJulia.clear_output
+IJulia.load
+IJulia.load_string
+```
+
+
+## I/O
+
+```@docs
+IJulia.readprompt
+IJulia.set_max_stdio
 ```

--- a/docs/src/library/public.md
+++ b/docs/src/library/public.md
@@ -15,6 +15,7 @@ IJulia.installkernel
 ```@docs
 IJulia.jupyterlab
 IJulia.notebook
+IJulia.qtconsole
 ```
 
 


### PR DESCRIPTION
Replaced single `@autodocs` block with explicit references to all functions/types/constants with docstrings and organized them under headers (also tried to sort them between the Public API / internals pages as best I could). Added a bunch more things to `@docs` blocks in internals page which seem like they should be documented but do not currently have docstrings.