### PR TITLE
Add kwarg julia_cmd to installkernel (to support JupyterHub with containers, etc.)

### DIFF
--- a/deps/kspec.jl
+++ b/deps/kspec.jl
@@ -47,7 +47,7 @@ end
 
 """
     installkernel(name::AbstractString, options::AbstractString...;
-                  julia_cmd::Cmd,
+                  julia::Cmd,
                   specname::AbstractString,
                   env=Dict())
 
@@ -68,22 +68,22 @@ directory (which defaults to `name` with spaces replaced by hyphens).
 
 You can uninstall the kernel by calling `rm(kernelpath, recursive=true)`.
 
-You can specify a custom `julia` command via `julia_cmd`. For example,
-you may want specify that the Julia kernel is running in a Docker
-container (but Jupyter will run outside of it), by calling `installkernel`
-from within such a container instance like this (or similar):
+You can specify a custom command to execute Julia via keyword argument
+`julia`. For example, you may want specify that the Julia kernel is running
+in a Docker container (but Jupyter will run outside of it), by calling
+`installkernel` from within such a container instance like this (or similar):
 
 ```
 installkernel(
     "Julia via Docker",
-    julia_cmd = `docker run --rm --net=host
+    julia = `docker run --rm --net=host
         --volume=/home/USERNAME/.local/share/jupyter:/home/USERNAME/.local/share/jupyter
         some-container /opt/julia-1.x/bin/julia`
 )
 ```
 """
 function installkernel(name::AbstractString, julia_options::AbstractString...;
-                   julia_cmd::Cmd = `$(joinpath(Sys.BINDIR,exe("julia")))`,
+                   julia::Cmd = `$(joinpath(Sys.BINDIR,exe("julia")))`,
                    specname::AbstractString = replace(lowercase(name), " "=>"-"),
                    env::Dict{<:AbstractString}=Dict{String,Any}())
     # Is IJulia being built from a debug build? If so, add "debug" to the description.
@@ -94,7 +94,7 @@ function installkernel(name::AbstractString, julia_options::AbstractString...;
     @info("Installing $name kernelspec in $juliakspec")
     rm(juliakspec, force=true, recursive=true)
     try
-        kernelcmd_array = String[julia_cmd.exec..., "-i",
+        kernelcmd_array = String[julia.exec..., "-i",
                                  "--startup-file=yes", "--color=yes"]
         append!(kernelcmd_array, julia_options)
         ijulia_dir = get(ENV, "IJULIA_DIR", dirname(@__DIR__)) # support non-Pkg IJulia installs


### PR DESCRIPTION
This PR makes it possible to specify a custom `julia` command via

```julia
installkernel(Julia, julia_cmd="my_custom_julia_start_script")
```

It also allows passing an array - this should be very helpful to people (like me :-) ) who often run Julia in Linux containers but may be forced (e.g. by using a site-wide JupyterHub) to have Jupyter running outside of the container.

For Docker, running

```julia
installkernel(
    "Julia via Docker",
    julia_cmd = [
        "docker", "run", "--rm", "--net=host",
        "--volume=/home/USERNAME/.local/share/jupyter:/home/USERNAME/.local/share/jupyter",
        "some-container", "/opt/julia-1.x/bin/julia"
    ]
)
```

from within a container instance now works - provided Docker has been set up in a way that supports things like this (e.g. the user is  "USERNAME" both inside and outside). I use Docker in this example because it's well known, though it is not necessarily the right runtime for such use cases (see below).

More and more scientific computing sites now offer JupyterHub instances and also support containers via runtimes like [Shifter](https://github.com/NERSC/shifter) or [Singularity](https://sylabs.io/)). Like with Docker, calling Julia ([or Python, for that matter](https://docs.nersc.gov/services/jupyter/#shifter-kernels-on-jupyter)) becomes a multi-part command (only simpler), e.g. `["shifter", "--image", "myimage", "/opt/julia/bin/julia"]`. This typically forces users to manually fiddle with their "kernel.json" files, which is inconvenient.

Having a `julia_cmd` kwarg (supporting both a simple string and a vectors of strings) should make life easier.