### PR TITLE
Allow users to opt out of the default kernel.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,8 +1,10 @@
 using Conda
 
-# Install Jupyter kernel-spec file.
-include("kspec.jl")
-kernelpath = installkernel("Julia", "--project=@.")
+if !haskey(ENV, "IJULIA_NODEFAULTKERNEL")
+    # Install Jupyter kernel-spec file.
+    include("kspec.jl")
+    kernelpath = installkernel("Julia", "--project=@.")
+end
 
 # make it easier to get more debugging output by setting JULIA_DEBUG=1
 # when building.

--- a/docs/src/manual/installation.md
+++ b/docs/src/manual/installation.md
@@ -73,6 +73,7 @@ installkernel("Julia (4 threads)", env=Dict("JULIA_NUM_THREADS"=>"4"))
 ```
 The `env` keyword should be a `Dict` mapping environment variables to values.
 
+To *prevent* IJulia from installing a default kernel when the package is built, define the `IJULIA_NODEFAULTKERNEL` environment variable before adding/building IJulia.
 
 ## Low-level Information
 


### PR DESCRIPTION
Shared Jupyter installations might want to be more selective.