### PR TITLE
Convert uuid4 to a string before using as msg_id

### DIFF
--- a/src/msg.jl
+++ b/src/msg.jl
@@ -15,7 +15,7 @@ mutable struct Msg
     end
 end
 
-msg_header(m::Msg, msg_type::String) = Dict("msg_id" => uuid4(),
+msg_header(m::Msg, msg_type::String) = Dict("msg_id" => string(uuid4()),
                                             "username" => m.header["username"],
                                             "session" => m.header["session"],
                                             "date" => now(),


### PR DESCRIPTION
`IJulia.uuid4()` is defined as `repr(UUIDs.uuid4())`, however repr(UUIDs.uuid4()) is rendered as `UUID(".......")`. The result is that in websocket responses from Jupyter, we see the following:
```
{"msg_id": "UUID(\\"f160847f-81ef-4c2f-b6b8-68659c81a957\\")", "msg_type": "status", "username": "username", "date": "2021-01-08T20:06:10.647000Z", "version": "5.3", "session": "1bbf2086-e46f-4174-bb88-72e75a09479d"}, "msg_id": "UUID(\\"f160847f-81ef-4c2f-b6b8-68659c81a957\\")", "msg_type": "status", "parent_header": {"msg_id": "317ec8d3-c7a0-4752-bb0d-137c4149268f", "notebook_uuid": "07423003-fd24-4681-911a-301054ffbcb7", "username": "username", "msg_type": "execute_request", "date": "2021-01-08T20:06:10.646228Z", "version": "5.0", "session": "1bbf2086-e46f-4174-bb88-72e75a09479d"}, "metadata": {}, "content": {"execution_state": "busy"}, "buffers": [], "channel": "iopub"}'
```

Wrapping it in a call to `string()` fixes this issue.