### PR TITLE
Change uuid to a string in all locations.

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -4,7 +4,7 @@ import Random: seed!
 # don't alter the user-visible random state (issue #336)
 const IJulia_RNG = seed!(Random.MersenneTwister(0))
 import UUIDs
-uuid4() = repr(UUIDs.uuid4(IJulia_RNG))
+uuid4() = string(UUIDs.uuid4(IJulia_RNG))
 
 const orig_stdin  = Ref{IO}()
 const orig_stdout = Ref{IO}()

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -15,7 +15,7 @@ mutable struct Msg
     end
 end
 
-msg_header(m::Msg, msg_type::String) = Dict("msg_id" => string(uuid4()),
+msg_header(m::Msg, msg_type::String) = Dict("msg_id" => uuid4(),
                                             "username" => m.header["username"],
                                             "session" => m.header["session"],
                                             "date" => now(),


### PR DESCRIPTION
It looks like my last MR #972 wasn't sufficient. This MR changes uuids to strings in all locations. Additionally, the call to `repr` is no longer required.