### PR TITLE
MacOS fixes for issue #968

### DIFF
--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -23,14 +23,14 @@ Base.displaysize(io::IJuliaStdio) = displaysize(io.io)
 Base.unwrapcontext(io::IJuliaStdio) = Base.unwrapcontext(io.io)
 Base.setup_stdio(io::IJuliaStdio, readable::Bool) = Base.setup_stdio(io.io.io, readable)
 
-for s in ("stdout", "stderr", "stdin")
-    f = Symbol("redirect_", s)
-    sq = QuoteNode(Symbol(s))
-    @eval function Base.$f(io::IJuliaStdio)
-        io[:jupyter_stream] != $s && throw(ArgumentError(string("expecting ", $s, " stream")))
-        Core.eval(Base, Expr(:(=), $sq, io))
-        return io
-    end
+function redirect_stream(which::String)
+    ssym = Symbol(which)
+    stream = eval(ssym)
+    io = IJuliaStdio(stream, which)
+    js = io[:jupyter_stream]
+    js != which && throw(ArgumentError("expecting $(which) stream, got $(js)"))
+    Core.eval(Base, Expr(:(=), ssym, io))
+    return io
 end
 
 # logging in verbose mode goes to original stdio streams.  Use macros

--- a/test/stdio.jl
+++ b/test/stdio.jl
@@ -4,23 +4,16 @@ using IJulia
 @testset "stdio" begin
 
     mktemp() do path, io
-        redirect_stdout(IJulia.IJuliaStdio(io, "stdout")) do
+        IJulia.redirect_stream("stdout", io) do
             println(Base.stdout, "stdout")
             println("print")
         end
         flush(io)
         seek(io, 0)
         @test read(io, String) == "stdout\nprint\n"
-        @test_throws ArgumentError redirect_stdout(IJulia.IJuliaStdio(io, "stderr"))
-        @test_throws ArgumentError redirect_stdout(IJulia.IJuliaStdio(io, "stdin"))
-        @test_throws ArgumentError redirect_stderr(IJulia.IJuliaStdio(io, "stdout"))
-        @test_throws ArgumentError redirect_stderr(IJulia.IJuliaStdio(io, "stdin"))
-        @test_throws ArgumentError redirect_stdin(IJulia.IJuliaStdio(io, "stdout"))
-        @test_throws ArgumentError redirect_stdin(IJulia.IJuliaStdio(io, "stderr"))
     end
-
     mktemp() do path, io
-        redirect_stderr(IJulia.IJuliaStdio(io, "stderr")) do
+        IJulia.redirect_stream("stderr", io) do
             println(Base.stderr, "stderr")
         end
         flush(io)
@@ -29,11 +22,10 @@ using IJulia
     end
 
     mktemp() do path, io
-        redirect_stdin(IJulia.IJuliaStdio(io, "stdin")) do
-            # We can't actually do anything here because `IJuliaexecute_msg` has not
-            # yet been initialized, so we just make sure that redirect_stdin does
-            # not error.
-        end
+        IJulia.redirect_stream("stdin")
+        # We can't actually do anything here because `IJuliaexecute_msg` has not
+        # yet been initialized, so we just make sure that redirect_stdin does
+        # not error.
     end
 
 end


### PR DESCRIPTION
Changes to run with Julia >1.5 on MacOS: heartbeat calls removed, dynamically-created
redirect functions replaced by one statically-created function to get around
problems with incremental compilation.