### PR TITLE
Correct kernelspec name

### DIFF
--- a/test/install.jl
+++ b/test/install.jl
@@ -21,4 +21,12 @@ import IJulia, JSON
             rm(kspec, force=true, recursive=true)
         end
     end
+
+    let kspec = IJulia.installkernel("ahzAHZ019.-_ ~!@#%^&*()")
+        try
+            @test occursin("ahzahz019.-_-__________", basename(kspec))
+        finally
+            rm(kspec, force=true, recursive=true)
+        end
+    end
 end


### PR DESCRIPTION
According to <https://jupyter-client.readthedocs.io/en/stable/kernels.html> 
> Since kernelspecs show up in URLs and other places, a kernelspec is required to have a simple name, only containing ASCII letters, ASCII numbers, and the simple separators: - hyphen, . period, _ underscore.

Below example from <https://julialang.github.io/IJulia.jl/stable/manual/installation/> will show un-correct logo in Jupyter Lab, because the kernelspec path contains `()` characters.
```julia
installkernel("Julia (4 threads)", env=Dict("JULIA_NUM_THREADS"=>"4"))
```
![ijulia-no-logo](https://user-images.githubusercontent.com/1846668/116572038-322fec00-a93e-11eb-977c-0a32767bf50f.PNG)
