### PR TITLE
Update help link

### DIFF
--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -168,7 +168,7 @@ function kernel_info_request(socket, msg)
                                                          Dict("text"=>"Julia Documentation",
                                                               "url"=>"http://docs.julialang.org/"),
                                                          Dict("text"=>"Julia Packages",
-                                                              "url"=>"http://pkg.julialang.org/")
+                                                              "url"=>"https://juliahub.com/ui/Packages")
                                                         ],
                                         "status" => "ok")))
 end


### PR DESCRIPTION
pkg.julialang.org is now an empty page (url used as a package server) so redirect instead to https://juliahub.com/ui/Packages