### PR TITLE
Compare kernel.jl files rather than filenames

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -3,7 +3,7 @@ import IJulia
 let
     ijulia_kernel_file = joinpath(dirname(pathof(IJulia)), "kernel.jl")
     this_kernel_file = @__FILE__
-    if ijulia_kernel_file != this_kernel_file
+    if stat(ijulia_kernel_file) != stat(this_kernel_file)
         @warn "this kernel.jl is different from the one provided by IJulia" this_kernel_file ijulia_kernel_file
     end
 end


### PR DESCRIPTION
Comparing filenames means we end up warning on directory level symlinks or file level hardlinks.
Using `stat` instead compares the device, inode, and other details about the file itself.