### PR TITLE
fix `jupyter kernelspec` invalid name warning

### DIFF
--- a/docs/src/manual/installation.md
+++ b/docs/src/manual/installation.md
@@ -69,7 +69,7 @@ You can also install kernels to run Julia with different environment
 variables, for example to set [`JULIA_NUM_THREADS`](https://docs.julialang.org/en/v1/manual/environment-variables/index.html#JULIA_NUM_THREADS-1) for use with Julia [multithreading](https://docs.julialang.org/en/v1/manual/parallel-computing/#Multi-Threading-(Experimental)-1):
 ```
 using IJulia
-installkernel("Julia (4 threads)", env=Dict("JULIA_NUM_THREADS"=>"4"))
+installkernel("Julia-4-threads", env=Dict("JULIA_NUM_THREADS"=>"4"))
 ```
 The `env` keyword should be a `Dict` mapping environment variables to values.
 


### PR DESCRIPTION
Kernel names can only contain ASCII letters and numbers and these separators: - . _ (hyphen, period, and underscore)

if the name contains other symbols like `( )` brackets and space, jupyter will give a warning and substitute all illegal symbol to `-`
![image](https://user-images.githubusercontent.com/59390321/144351742-f37e3b2f-061c-4acc-8395-a4ddd2cf8561.png)
