### PR TITLE
Propose increasing number of columns to 800

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.23.3"
+version = "1.24.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/manual/usage.md
+++ b/docs/src/manual/usage.md
@@ -92,7 +92,7 @@ empty!(Out)
 
 When Julia displays a large data structure such as a matrix, by default
 it truncates the display to a given number of lines and columns.  In IJulia,
-this truncation is to 30 lines and 80 columns by default.   You can change
+this truncation is to 30 lines and 800 columns by default.   You can change
 this default by the `LINES` and `COLUMNS` environment variables, respectively,
 which can also be changed within IJulia via `ENV` (e.g. `ENV["LINES"] = 60`).
 (Like in the REPL, you can also display non-truncated data structures via `print(x)`.)

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -19,7 +19,7 @@ end
 # the size of truncated output to show should not depend on the terminal
 # where the kernel is launched, since the display is elsewhere
 ENV["LINES"] = get(ENV, "LINES", 30)
-ENV["COLUMNS"] = get(ENV, "COLUMNS", 80)
+ENV["COLUMNS"] = get(ENV, "COLUMNS", 800)
 
 IJulia.init(ARGS)
 


### PR DESCRIPTION
80 columns in HTML is a very small number given current standards. Especially that browser creates horizontal scroll bar when displaying an object. This should not have a big impact on performance either.

I think leaving 30 lines is OK.