### PR TITLE
ensure JSONText is never base64-encoded

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -87,7 +87,7 @@ function display_mimejson(mime_array::Vector{MIME}, x)
     error("No displayable MIME types in mime array.")
 end
 
-display_mimejson(m::MIME, x) = (m, JSON.JSONText(limitstringmime(m, x)))
+display_mimejson(m::MIME, x) = (m, JSON.JSONText(limitstringmime(m, x, true)))
 
 """
 Generate a dictionary of `mime_type => data` pairs for all registered MIME

--- a/src/inline.jl
+++ b/src/inline.jl
@@ -34,9 +34,9 @@ InlineIOContext(io, KVs::Pair...) = IOContext(
 
 # convert x to a string of type mime, making sure to use an
 # IOContext that tells the underlying show function to limit output
-function limitstringmime(mime::MIME, x)
+function limitstringmime(mime::MIME, x, forcetext=false)
     buf = IOBuffer()
-    if istextmime(mime)
+    if forcetext || istextmime(mime)
         if israwtext(mime, x)
             return String(x)
         else


### PR DESCRIPTION
Fixes #1073.

As commented in https://github.com/JuliaLang/IJulia.jl/issues/1073#issuecomment-1574053797, it really seems like Plotly.jl should define `istextmime` for `application/vnd.plotly.v1+json`, but in any case since we know this should be JSON text IJulia can ensure that it is not base64 encoded.

cc @sglyon who added support for this MIME type in #773