### PR TITLE
don't store Out in itself

### DIFF
--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -71,7 +71,7 @@ function execute_request(socket, msg)
 
         if silent
             result = nothing
-        elseif result !== nothing
+        elseif (result !== nothing) && (result !== Out)
             if store_history
                 Out[n] = result
             end


### PR DESCRIPTION
This stops you from getting cycling references to `Out` if you return `Out` from a cell. 