### PR TITLE
ignore unknown request types

### DIFF
--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -5,7 +5,7 @@ function eventloop(socket)
             msg = recv_ipython(socket)
             try
                 send_status("busy", msg)
-                invokelatest(handlers[msg.header["msg_type"]], socket, msg)
+                invokelatest(get(handlers, msg.header["msg_type"], unknown_request), socket, msg)
             catch e
                 # Try to keep going if we get an exception, but
                 # send the exception traceback to the front-ends.

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -274,6 +274,10 @@ function interrupt_request(socket, msg)
     send_ipython(requests[], msg_reply(msg, "interrupt_reply", Dict()))
 end
 
+function unknown_request(socket, msg)
+    @vprintln("UNKNOWN MESSAGE TYPE $(msg.header["msg_type"])")
+end
+
 const handlers = Dict{String,Function}(
     "execute_request" => execute_request,
     "complete_request" => complete_request,


### PR DESCRIPTION
Jupyter extensions can generate arbitrary new request types, apparently, which this PR ignores (rather than throwing an exception).  Workaround for #1091.