### PR TITLE
Prefer to `show` `AbstractString`s with text mimes

### DIFF
--- a/src/inline.jl
+++ b/src/inline.jl
@@ -22,7 +22,7 @@ const ipy_mime = [
 # need special handling for showing a string as a textmime
 # type, since in that case the string is assumed to be
 # raw data unless it is text/plain
-israwtext(::MIME, x::AbstractString) = true
+israwtext(m::MIME, x::AbstractString) = !showable(m, x)
 israwtext(::MIME"text/plain", x::AbstractString) = false
 israwtext(::MIME, x) = false
 


### PR DESCRIPTION
`israwtext` assumed that an `AbstractString` with a text MIME was already in the requested format. Instead, only assume this if the string is not otherwise `showable`. This enables customizing the display of `AbstractString`s.

Closes #1113.