### PR TITLE
Fix `register_comm` invalidations

### DIFF
--- a/src/comm_manager.jl
+++ b/src/comm_manager.jl
@@ -106,7 +106,7 @@ function comm_open(sock, msg)
                 msg.content["data"] = Dict()
             end
             comm = Comm(target, comm_id, false)
-            register_comm(comm, msg)
+            invokelatest(register_comm, comm, msg)
             comms[comm_id] = comm
         else
             # Tear down comm to maintain consistency


### PR DESCRIPTION
Minor bug: [`register_comm`](https://github.com/JuliaLang/IJulia.jl/blob/fb76275b2ada0f586c0d1da9cbe674fee58e3bde/src/comm_manager.jl#L92) gets invalidated by design, when other packages (WebIO, JSServe, and Bonito that I'm aware of) define a new `register_comm` method.

Invalidation reproducer (from Jupyter):
```
using IJulia, SnoopCompileCore

invs = @snoop_invalidations using WebIO;

using SnoopCompile, AbstractTrees
trees = invalidation_trees(invs)
```

which gives
```
 inserting register_comm(comm::IJulia.CommManager.Comm{:webio_comm}, x) @ IJuliaExt ~/.julia/dev/WebIO/ext/IJuliaExt.jl:19 invalidated:
   backedges: 1: superseding register_comm(comm::IJulia.CommManager.Comm, data) @ IJulia.CommManager ~/Dropbox/documents/technology/development/julia-dev/IJulia/src/comm_manager.jl:92 with MethodInstance for register_comm(::IJulia.CommManager.Comm, ::IJulia.Msg) (1 children)
```

This PR changes the  `register_comm` call to use `invokelatest`. This shouldn't be a performance sensitive issue, since register_comm should normally only be called once per comm connection.