### PR TITLE
Make message receive and handling async

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,6 +23,9 @@ ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
+[sources]
+ZMQ = {url = "https://github.com/JuliaInterop/ZMQ.jl.git", rev = "poller"}
+
 [extensions]
 IJuliaPythonCallExt = "PythonCall"
 IJuliaReviseExt = "Revise"

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -130,6 +130,12 @@ REPL.REPLDisplay(repl::MiniREPL) = repl.display
     requests::RefValue{Socket} = Ref{Socket}()
     control::RefValue{Socket} = Ref{Socket}()
     heartbeat::RefValue{Socket} = Ref{Socket}()
+
+    requests_inproc_push::RefValue{Socket} = Ref{Socket}()
+    requests_inproc_pull::RefValue{Socket} = Ref{Socket}()
+    control_inproc_push::RefValue{Socket} = Ref{Socket}()
+    control_inproc_pull::RefValue{Socket} = Ref{Socket}()
+
     zmq_context::RefValue{Context} = Ref{Context}()
     profile::Dict{String, Any} = Dict{String, Any}()
     connection_file::Union{String, Nothing} = nothing
@@ -579,8 +585,8 @@ function init_matplotlib end
 
 include("init.jl")
 include("hmac.jl")
-include("eventloop.jl")
 include("stdio.jl")
+include("eventloop.jl")
 include("msg.jl")
 include("display.jl")
 include("magics.jl")

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -35,6 +35,7 @@ export notebook, jupyterlab, nbclassic, installkernel
 
 import SHA
 using ZMQ
+using ZMQ: Poller
 import Base: invokelatest, RefValue
 import Dates
 using Dates: now, format, UTC, ISODateTimeFormat

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -131,8 +131,10 @@ REPL.REPLDisplay(repl::MiniREPL) = repl.display
     control::RefValue{Socket} = Ref{Socket}()
     heartbeat::RefValue{Socket} = Ref{Socket}()
 
+    requests_poller::RefValue{Poller} = Ref{Poller}()
     requests_inproc_push::RefValue{Socket} = Ref{Socket}()
     requests_inproc_pull::RefValue{Socket} = Ref{Socket}()
+    control_poller::RefValue{Poller} = Ref{Poller}()
     control_inproc_push::RefValue{Socket} = Ref{Socket}()
     control_inproc_pull::RefValue{Socket} = Ref{Socket}()
 
@@ -247,10 +249,17 @@ function Base.close(kernel::Kernel)
     end
     popdisplay()
 
+    close(kernel.control_poller[])
+    close(kernel.requests_poller[])
     start_shutdown(kernel)
-    wait(kernel)
 
     # Close all sockets
+    close(kernel.requests_inproc_push[])
+    close(kernel.requests_inproc_pull[])
+    close(kernel.control_inproc_push[])
+    close(kernel.control_inproc_pull[])
+    wait(kernel)
+
     close(kernel.publish[])
     close(kernel.raw_input[])
     close(kernel.requests[])

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -151,6 +151,7 @@ REPL.REPLDisplay(repl::MiniREPL) = repl.display
     completion_precompile_task::RefValue{Task} = Ref{Task}()
 
     requests_task::RefValue{Task} = Ref{Task}()
+    iopub_task::RefValue{Task} = Ref{Task}()
     watch_stdout_task::RefValue{Task} = Ref{Task}()
     watch_stderr_task::RefValue{Task} = Ref{Task}()
     flush_stdout_task::RefValue{Task} = Ref{Task}()

--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -1,74 +1,122 @@
 """
-    eventloop(socket, kernel)
+    eventloop(socket, kernel, msgs, handlers)
 
 Generic event loop for one of the [kernel
 sockets](https://jupyter-client.readthedocs.io/en/latest/messaging.html#introduction).
 """
-function eventloop(socket, kernel)
-    task_local_storage(:IJulia_task, "write task")
-    while true
+function eventloop(socket, kernel, msgs, handlers)
+    while isopen(msgs)
         try
-            local msg
-            try
-                msg = recv_ipython(socket, kernel)
-            catch e
-                if isa(e, EOFError)
-                    # The socket was closed
-                    return
-                else
-                    rethrow()
+            while isopen(msgs)
+                msg = take!(msgs) # can throw if `msgs` is closed while waiting on it
+                try
+                    send_status("busy", kernel, msg)
+                    invokelatest(get(handlers, msg.header["msg_type"], unknown_request), socket, kernel, msg)
+                catch e
+                    if e isa InterruptException && kernel.shutting_down[]
+                        # If we're shutting down, just return immediately
+                        return
+                    elseif !isa(e, InterruptException)
+                        # Try to keep going if we get an exception, but
+                        # send the exception traceback to the front-ends.
+                        # (Ignore SIGINT since this may just be a user-requested
+                        #  kernel interruption to interrupt long calculations.)
+                        content = error_content(e, msg="KERNEL EXCEPTION")
+                        map(s -> println(orig_stderr[], s), content["traceback"])
+                        send_ipython(kernel.publish[], kernel, msg_pub(kernel.execute_msg, "error", content))
+                    end
+                finally
+                    flush_all()
+                    send_status("idle", kernel, msg)
                 end
-            end
-
-            try
-                send_status("busy", kernel, msg)
-                msg_type = msg.header["msg_type"]::String
-                invokelatest(get(handlers, msg_type, unknown_request), socket, kernel, msg)
-            catch e
-                if e isa InterruptException && kernel.shutting_down[]
-                    # If we're shutting down, just return immediately
-                    return
-                elseif !isa(e, InterruptException)
-                    # Try to keep going if we get an exception, but
-                    # send the exception traceback to the front-ends.
-                    # (Ignore SIGINT since this may just be a user-requested
-                    #  kernel interruption to interrupt long calculations.)
-                    content = error_content(e, msg="KERNEL EXCEPTION")
-                    map(s -> println(orig_stderr[], s), content["traceback"])
-                    send_ipython(kernel.publish[], kernel, msg_pub(kernel.execute_msg, "error", content))
-                end
-            finally
-                flush_all()
-                send_status("idle", kernel, msg)
+                yield()
             end
         catch e
-            if kernel.shutting_down[]
+            if kernel.shutting_down[] || isa(e, ZMQ.StateError) || isa(e, InvalidStateException)
+                # a ZMQ.StateError is almost certainly because of a closed socket
+                # an InvalidStateException is because of a closed channel
                 return
-            end
-
-            # the Jupyter manager may send us a SIGINT if the user
-            # chooses to interrupt the kernel; don't crash on this
-            if isa(e, InterruptException)
-                continue
-            elseif isa(e, ZMQ.StateError)
-                # This is almost certainly because of a closed socket
-                return
-            else
+            elseif !isa(e, InterruptException)
+                # the Jupyter manager may send us a SIGINT if the user
+                # chooses to interrupt the kernel; don't crash for that
                 rethrow()
             end
         end
+        yield()
     end
 end
 
 """
     waitloop(kernel)
 
-Main loop of a kernel. Runs the event loops for the control and shell sockets
+Main loop of a kernel. Runs the event loops for the control, shell, and iopub sockets
 (note: in IJulia the shell socket is called `requests`).
 """
 function waitloop(kernel)
-    control_task = @async eventloop(kernel.control[], kernel)
-    kernel.requests_task[] = @async eventloop(kernel.requests[], kernel)
+    control_msgs = Channel{Msg}(32) do ch
+        task_local_storage(:IJulia_task, "control msgs receive task")
+        while isopen(kernel.control[])
+            try
+                msg::Msg = recv_ipython(kernel.control[], kernel)
+                put!(ch, msg)
+            catch e
+                if kernel.shutting_down[] || isa(e, EOFError)
+                    # an EOFError is because of a closed socket
+                    return
+                else
+                    rethrow()
+                end
+            end
+            yield()
+        end
+    end
+
+    iopub_msgs = Channel{Msg}(32)
+    request_msgs = Channel{Msg}(32) do ch
+        task_local_storage(:IJulia_task, "request msgs receive task")
+        while isopen(kernel.requests[])
+            try
+                msg::Msg = recv_ipython(kernel.requests[], kernel)
+                if haskey(iopub_handlers, msg.header["msg_type"])
+                    put!(iopub_msgs, msg)
+                else
+                    put!(ch, msg)
+                end
+            catch e
+                if kernel.shutting_down[] || isa(e, EOFError)
+                    close(iopub_msgs) # otherwise iopubs_msg would remain open, but with no producer anymore
+                    # an EOFError is because of a closed socket
+                    return
+                else
+                    rethrow()
+                end
+            end
+            yield()
+        end
+    end
+
+    # tasks must all be on the same thread as the `waitloop` calling thread, because
+    # `throwto` can't cross/change threads
+    control_task = @async begin
+        task_local_storage(:IJulia_task, "control handle/write task")
+        eventloop(kernel.control[], kernel, control_msgs, handlers)
+    end
+    kernel.requests_task[] = @async begin
+        task_local_storage(:IJulia_task, "requests handle/write task")
+        eventloop(kernel.requests[], kernel, request_msgs, handlers)
+    end
+    kernel.iopub_task[] = @async begin
+        task_local_storage(:IJulia_task, "iopub handle/write task")
+        eventloop(kernel.requests[], kernel, iopub_msgs, iopub_handlers)
+    end
+
+    # msg channels should close when tasks are terminated
+    bind(control_msgs, control_task)
+    bind(request_msgs, kernel.requests_task[])
+    # unhandled errors in iopub_task should also kill the request_msgs channel (since we
+    # currently don't restart a failed iopub task)
+    bind(request_msgs, kernel.iopub_task[])
+    bind(iopub_msgs, kernel.iopub_task[])
 
     while kernel.inited
         try
@@ -77,15 +125,15 @@ function waitloop(kernel)
             # send interrupts (user SIGINT) to the code-execution task
             if isa(e, InterruptException)
                 @async Base.throwto(kernel.requests_task[], e)
+                @async Base.throwto(kernel.iopub_task[], e)
             else
                 rethrow()
             end
-        finally
-            # Only wait for tasks if we're actually exiting the loop
-            if !kernel.inited
-                wait(control_task)
-                wait(kernel.requests_task[])
-            end
+        else
+            # only wait for tasks to finish for a non-error'ed try wait
+            wait(control_task)
+            wait(kernel.requests_task[])
+            wait(kernel.iopub_task[])
         end
     end
 end

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -186,7 +186,7 @@ function execute_request(socket, kernel, msg)
                                       "data" => result_data)))
 
         end
-        send_ipython(kernel.requests[], kernel,
+        send_ipython(socket, kernel,
                      msg_reply(msg, "execute_reply",
                                Dict("status" => "ok",
                                     "payload" => kernel.execute_payloads,
@@ -213,6 +213,6 @@ function execute_request(socket, kernel, msg)
         send_ipython(kernel.publish[], kernel, msg_pub(msg, "error", content))
         content["status"] = "error"
         content["execution_count"] = kernel.n
-        send_ipython(kernel.requests[], kernel, msg_reply(msg, "execute_reply", content))
+        send_ipython(socket, kernel, msg_reply(msg, "execute_reply", content))
     end
 end

--- a/src/handlers.jl
+++ b/src/handlers.jl
@@ -448,7 +448,7 @@ function unknown_request(socket, kernel, msg)
     @vprintln("UNKNOWN MESSAGE TYPE $(msg.header["msg_type"])")
 end
 
-const handlers = Dict{String,Function}(
+const HANDLERS = Dict{String,Function}(
     "execute_request" => execute_request,
     "complete_request" => complete_request,
     "kernel_info_request" => kernel_info_request,
@@ -464,7 +464,7 @@ const handlers = Dict{String,Function}(
     "comm_close" => comm_close,
 )
 
-const iopub_handlers = Dict{String,Function}(
+const IOPUB_HANDLERS = Dict{String,Function}(
     "comm_open" => comm_open,
     "comm_msg" => comm_msg,
     "comm_close" => comm_close,

--- a/src/init.jl
+++ b/src/init.jl
@@ -144,6 +144,10 @@ function init(args, kernel, profile=nothing)
         connect(send_ref[], "inproc://ijulia-$(name)")
     end
 
+    # Create pollers
+    kernel.control_poller[] = Poller([kernel.control[], kernel.control_inproc_pull[]])
+    kernel.requests_poller[] = Poller([kernel.requests[], kernel.requests_inproc_pull[]])
+
     # associate a lock with each socket so that multi-part messages
     # on a given socket don't get inter-mingled between tasks.
     for s in (kernel.publish[], kernel.raw_input[], kernel.requests[], kernel.control[],

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -120,6 +120,6 @@ end
 precompile(run_kernel, ())
 
 # Precompile all the handlers
-for f in values(handlers)
+for f in values(HANDLERS)
     precompile(f, (ZMQ.Socket, Kernel, Msg))
 end

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -97,7 +97,7 @@ function watch_stream(rd::IO, name::AbstractString, kernel)
         catch e
             # the IPython manager may send us a SIGINT if the user
             # chooses to interrupt the kernel; don't crash on this
-            if isa(e, InterruptException)
+            if isa(e, InterruptException) && isassigned(kernel.requests_task)
                 @async Base.throwto(kernel.requests_task[], e)
             else
                 rethrow()
@@ -244,7 +244,7 @@ function flush_loop(name::String, io::IO, kernel::Kernel, interval::Float64)
             sleep(interval)
             send_stdio(name, kernel)
         catch e
-            if isa(e, InterruptException)
+            if isa(e, InterruptException) && isassigned(kernel.requests_task)
                 @async Base.throwto(kernel.requests_task[], e)
             else
                 @error "Exception in flush_loop()" exception=(e, catch_backtrace())

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -246,6 +246,11 @@ function flush_loop(name::String, io::IO, kernel::Kernel, interval::Float64)
         catch e
             if isa(e, InterruptException) && isassigned(kernel.requests_task)
                 @async Base.throwto(kernel.requests_task[], e)
+            elseif kernel.shutting_down[] || isa(e, ZMQ.StateError)
+                # During shutdown the ZMQ context is terminated out from under
+                # us, so a final flush fails with a StateError("Context was
+                # terminated"). This is expected so we ignore it.
+                return
             else
                 @error "Exception in flush_loop()" exception=(e, catch_backtrace())
             end

--- a/test/stress_test.jl
+++ b/test/stress_test.jl
@@ -1,0 +1,286 @@
+# Stress test for the IJulia eventloop and ZMQ polling.
+#
+# Hammers the kernel with rapid, overlapping requests across multiple channels
+# to surface race conditions, spurious wakeups, and polling bugs.
+#
+# Usage:
+#   julia --project=@. test/stress_test.jl [rounds]
+#
+# `rounds` defaults to 10. Each round spins up a fresh kernel and runs a battery
+# of high-throughput request patterns against it.
+
+using TestEnv; TestEnv.activate()
+
+# ── CondaPkg / PythonCall bootstrap (copied from kernel.jl) ──────────────
+cp(joinpath(@__DIR__, "CondaPkg.toml"),
+   joinpath(dirname(Base.active_project()), "CondaPkg.toml"); force=true)
+ENV["JULIA_CONDAPKG_ENV"] = "@ijulia-tests"
+ENV["JULIA_CONDAPKG_VERBOSITY"] = "-1"
+
+using Test
+import Sockets
+import ZMQ
+import PythonCall
+import PythonCall: Py, pyimport, pyconvert, pytype, pystr
+
+jupyter_client_lib = pyimport("jupyter_client")
+jupyter_client_lib.session.protocol_version = "5.4"
+const BlockingKernelClient = jupyter_client_lib.BlockingKernelClient
+
+import IJulia
+import IJulia: Kernel
+
+# ── Helpers (shared with kernel.jl) ──────────────────────────────────────
+
+function test_py_get!(get_func, result)
+    try
+        result[] = get_func(timeout=0)
+        return true
+    catch ex
+        exception_type = pyconvert(String, ex.t.__name__)
+        exception_type == "Empty" || rethrow()
+        return false
+    end
+end
+
+function recursive_pyconvert(x)
+    x_type = pyconvert(String, pytype(x).__name__)
+    if x_type == "dict"
+        x = pyconvert(Dict{String, Any}, x)
+        for key in copy(keys(x))
+            if x[key] isa Py
+                x[key] = recursive_pyconvert(x[key])
+            elseif x[key] isa PythonCall.PyDict
+                x[key] = recursive_pyconvert(x[key].py)
+            end
+        end
+    elseif x_type == "str"
+        x = pyconvert(String, x)
+    end
+    return x
+end
+
+function make_request(request_func, get_func, args...; wait=true, timeout=20, kwargs...)
+    request_func(args...; kwargs..., reply=false)
+    wait || return nothing
+    result = Ref{Py}()
+    if timedwait(() -> test_py_get!(get_func, result), timeout) == :timed_out
+        error("Jupyter channel get timed out")
+    end
+    return recursive_pyconvert(result[])
+end
+
+kernel_info(client)       = make_request(client.kernel_info,  client.get_shell_msg)
+comm_info(client)         = make_request(client.comm_info,    client.get_shell_msg)
+history(client)           = make_request(client.history,      client.get_shell_msg)
+execute(client, code)     = make_request(client.execute,      client.get_shell_msg; code)
+inspect(client, code)     = make_request(client.inspect,      client.get_shell_msg; code)
+complete(client, code)    = make_request(client.complete,     client.get_shell_msg; code)
+shutdown(client; wait=true) = make_request(client.shutdown, client.get_control_msg; wait)
+get_iopub_msg(client)     = make_request(Returns(nothing), client.get_iopub_msg)
+
+function drain_iopub(client; timeout=5)
+    count = 0
+    deadline = time() + timeout
+    while time() < deadline
+        result = Ref{Py}()
+        if test_py_get!(client.get_iopub_msg, result)
+            count += 1
+        else
+            sleep(0.05)
+        end
+    end
+    return count
+end
+
+msg_ok(msg) = msg["content"]["status"] == "ok"
+msg_error(msg) = msg["content"]["status"] == "error"
+
+function jupyter_client(f, profile)
+    client = BlockingKernelClient()
+    client.load_connection_info(profile)
+    client.start_channels()
+    try
+        f(client)
+    finally
+        client.stop_channels()
+    end
+end
+
+# ── Stress-test batteries ───────────────────────────────────────────────
+
+"""
+Rapid-fire execute requests: send N executions as fast as possible, then
+collect all N replies. Exercises the requests conductor poll loop, channel
+throughput, and inproc forwarding.
+"""
+function stress_rapid_execute!(client, n)
+    @info "  rapid execute: $n requests"
+    # fire all requests without waiting
+    for i in 1:n
+        client.execute("$i + $i"; reply=false)
+    end
+    # collect all replies
+    for i in 1:n
+        result = Ref{Py}()
+        if timedwait(() -> test_py_get!(client.get_shell_msg, result), 30) == :timed_out
+            error("rapid execute timed out at reply $i/$n")
+        end
+        msg = recursive_pyconvert(result[])
+        msg["content"]["status"] == "ok" || error("rapid execute failed at $i: $(msg["content"])")
+    end
+end
+
+"""
+Interleaved request types: alternate between execute, complete, inspect,
+kernel_info, comm_info, and history. Exercises handler dispatch and makes
+sure different msg_types don't step on each other.
+"""
+function stress_interleaved_requests!(client, n)
+    @info "  interleaved requests: $n cycles"
+    for i in 1:n
+        @assert msg_ok(execute(client, "x_$i = $i"))
+        @assert msg_ok(complete(client, "prin"))
+        @assert msg_ok(kernel_info(client))
+        @assert msg_ok(inspect(client, "println"))
+        @assert msg_ok(comm_info(client))
+        @assert msg_ok(history(client))
+    end
+end
+
+"""
+Stdout-heavy execution: code that prints many lines, generating lots of
+iopub stream messages. Stresses the publish socket and iopub forwarding.
+"""
+function stress_stdout_flood!(client, lines)
+    @info "  stdout flood: $lines lines"
+    code = """
+    for i in 1:$lines
+        println("line ", i)
+    end
+    """
+    msg = execute(client, code)
+    msg_ok(msg) || error("stdout flood execution failed: $(msg["content"])")
+    drain_iopub(client; timeout=10)
+end
+
+"""
+Rapid completions: fire many tab-completion requests. Stresses the shell
+socket with small, fast round-trips.
+"""
+function stress_rapid_completions!(client, n)
+    @info "  rapid completions: $n requests"
+    prefixes = ["prin", "Base.", "mk", "is", "read", "write", "parse", "split"]
+    for i in 1:n
+        prefix = prefixes[mod1(i, length(prefixes))]
+        msg = complete(client, prefix)
+        msg_ok(msg) || error("rapid completion failed at $i: $(msg["content"])")
+    end
+end
+
+"""
+Comm open/msg/close cycles: rapidly create, message, and tear down comms.
+Exercises iopub handler (comm messages route through IOPUB_HANDLERS) and
+the comm registry on the kernel.
+"""
+function stress_comms!(client, kernel, n)
+    @info "  comm cycles: $n"
+    for i in 1:n
+        comm_id = "stress-comm-$i"
+        open_msg = IJulia.Msg(
+            ["stress"],
+            Dict("username" => "stress", "session" => "stress-session"),
+            Dict("comm_id" => comm_id, "target_name" => "stress_target", "data" => Dict()))
+        IJulia.comm_open(kernel.requests[], kernel, open_msg)
+
+        if haskey(kernel.comms, comm_id)
+            IJulia.send_comm(kernel.comms[comm_id], Dict("i" => i))
+
+            close_msg = IJulia.Msg(
+                ["stress"],
+                Dict("username" => "stress", "session" => "stress-session"),
+                Dict("comm_id" => comm_id, "data" => Dict()))
+            IJulia.comm_close(kernel.requests[], kernel, close_msg)
+        end
+    end
+    drain_iopub(client; timeout=5)
+end
+
+"""
+Mixed concurrent load: interleave stdout-heavy executes with completions.
+The execute generates iopub traffic while completions exercise the shell
+socket simultaneously.
+"""
+function stress_mixed_load!(client, n)
+    @info "  mixed load: $n iterations"
+    for i in 1:n
+        # An execute that produces some output
+        msg = execute(client, """
+            for j in 1:10
+                println("mixed-$i-", j)
+            end
+            $i * 2
+        """)
+        msg_ok(msg) || error("mixed load execute failed at $i: $(msg["content"])")
+        # Immediately follow with a completion
+        msg = complete(client, "Base.pri")
+        msg_ok(msg) || error("mixed load completion failed at $i: $(msg["content"])")
+    end
+end
+
+"""
+Async output stress: execute code that spawns tasks writing to stdout
+concurrently. This creates many iopub messages from multiple sources.
+"""
+function stress_async_output!(client, ntasks, lines_per_task)
+    @info "  async output: $ntasks tasks x $lines_per_task lines"
+    code = """
+    tasks = map(1:$ntasks) do t
+        Threads.@spawn begin
+            for i in 1:$lines_per_task
+                println("task-", t, " line-", i)
+            end
+        end
+    end
+    foreach(wait, tasks)
+    "done"
+    """
+    msg = execute(client, code)
+    msg_ok(msg) || error("async output execution failed: $(msg["content"])")
+    drain_iopub(client; timeout=10)
+end
+
+# ── Main loop ────────────────────────────────────────────────────────────
+
+const ROUNDS = length(ARGS) >= 1 ? parse(Int, ARGS[1]) : 10
+
+@info "Starting stress test" rounds=ROUNDS
+
+for round in 1:ROUNDS
+    @info "══ Round $round/$ROUNDS ══"
+    profile = IJulia.create_profile(; key=IJulia._TEST_KEY)
+
+    Kernel(profile; capture_stdout=true, capture_stderr=false) do kernel
+        jupyter_client(profile) do client
+            # Warm up
+            @assert msg_ok(kernel_info(client))
+            @assert msg_ok(execute(client, "1 + 1"))
+
+            stress_rapid_execute!(client, 50)
+            stress_interleaved_requests!(client, 10)
+            stress_stdout_flood!(client, 500)
+            stress_rapid_completions!(client, 50)
+            stress_comms!(client, kernel, 30)
+            stress_mixed_load!(client, 20)
+            stress_async_output!(client, 5, 50)
+
+            # Clean shutdown
+            shutdown(client; wait=false)
+            sleep(0.1)
+        end
+    end
+
+    @info "Round $round passed"
+end
+
+@info "All $ROUNDS rounds passed"

--- a/test_repeat.sh
+++ b/test_repeat.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Repeatedly run IJulia tests. Stops immediately if stderr contains "Spurious WAKEUP".
+# Ctrl-C stops everything at any time.
+
+run=0
+while true; do
+    run=$((run + 1))
+    echo "=== Run $run ==="
+
+    # fd 3 = original stdout. Pipe captures julia's stderr; stdout passes through.
+    { julia --color=yes --project=@. -e "using Pkg; Pkg.test()" 2>&1 1>&3 3>&- | \
+        while IFS= read -r line; do
+            printf '%s\n' "$line" >&2
+            if [[ "$line" == *"Spurious WAKEUP"* ]]; then
+                printf '\n*** "Spurious WAKEUP" detected on run %d — stopping. ***\n' "$run" >&2
+                kill -INT -- 0
+            fi
+        done
+    } 3>&1
+
+    exit_code=${PIPESTATUS[0]}
+    if [ "$exit_code" -ne 0 ]; then
+        printf '*** Tests failed on run %d (exit code %d) — stopping. ***\n' "$run" "$exit_code"
+        exit "$exit_code"
+    fi
+
+    echo "Run $run passed."
+done


### PR DESCRIPTION
## Motivation

All messages from the front-end/server are received and handled synchronously, including [custom comm messages](https://jupyter-client.readthedocs.io/en/latest/messaging.html#custom-messages) (`comm_open`, `comm_msg`, and `comm_close`). So, any currently executing cell blocks the IJulia kernel from receiving and handling any IOPub/comm messages. For example, in the following WebIO MWE, a JS function updates an "output" `Observable`, and the JS function is triggered by setting an ("input") observable:

```julia
using WebIO, Observables
s = Scope()
s["in"] = Observable{String}("")
s["out"] = Observable{String}("")
onjs(s["in"], js"""
function (val)
    _webIOScope.setObservableValue("out",val);
end""")
```

you can't observe a new `s["out"]` value (aka the result of the JS function) during execution of the same cell that set `s["in"]` (which triggers the JS function).

<details><summary>Example Julia function that fails (hangs) without async comms</summary>
<p>

```julia
function julia_js_julia(_in, out, str)
    ch = Channel{String}()
    obsf = on(out) do val
        put!(ch, val)
    end
    t = @async take!(ch)
    _in[] = str
    out = fetch(t)
    off(obsf)
        
    return out
end
```

*This example function isn't thread-safe. (The `scp["in"]` observable isn't locked, so concurrently setting it could lead to interleaved/mismatched updates to the `scp["out"]` observable.)
</p>
</details> 

One example of an actual use-case/benefit is `PlotlyJS.to_image`, which uses the same 
Julia => JS => Julia observable setup to retrieve the results of a plotly.js function call.
Currently, the `PlotlyJS.to_image` function soft-fails because the observable that holds the generated
image is only updated after the current cell finishes execution (when IJulia can process the
`comm_msg` from WebIO in the Jupyter frontend/client).

## Testing

I've manually tested that the above WebIO MWE works with this PR, and that interrupting still works. I realize this is a fairly fundamental rearchitecturing of the message receiving/handling, but I'm not sure what else to test and/or if there is a good way to test any of this in CI. I'm open to any hints/pointers if you want more thorough testing/test cases.

Fixes #858.

P.S. Breadcrumb for the future: This new architecture has a lot of parallels (easily adapted) to the new [subshells feature](https://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-subshells) that was recently implemented in ipython/ipykernel#1249.

