### PR TITLE
Add locks around the IO buffers for threadsafety

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -17,3 +17,5 @@ Changelog](https://keepachangelog.com).
 - The internal heartbeat thread will now shut down cleanly ([#1135],
   [#1144]). This should prevent segfaults upon exit.
 - Various fixes to the messaging code to be compliant with Jupyter ([#1138]).
+- Improved threadsafety of the IO-handling code so that it should be safe to
+  call `flush()` concurrently ([#1149]).


### PR DESCRIPTION
@EdsterG, I wasn't able to reproduce the error with `safe_lock=1`, but without it I could reproduce it on a machine with 128 threads. This patch fixed it for me.

Fixes #1148.