### PR TITLE
Support echoing the output from `notebook()` and `jupyterlab()`

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -9,6 +9,11 @@ Changelog](https://keepachangelog.com).
 
 ## Unreleased
 
+### Added
+- [`notebook()`](@ref) and [`jupyterlab()`](@ref) now support a `verbose`
+  keyword argument to echo output from Jupyter to the terminal, which can be
+  useful when debugging kernels ([#1157]).
+
 ### Fixed
 
 - The Julia major and minor version are no longer appended to a custom


### PR DESCRIPTION
Also deleted the Mac workaround since 10.12 has been EOL since 2019.

(CC @goerz)