### PR TITLE
Move kernel.jl into a function in the IJulia module

### DIFF
--- a/deps/kspec.jl
+++ b/deps/kspec.jl
@@ -123,7 +123,7 @@ function installkernel(name::AbstractString, julia_options::AbstractString...;
         kernelcmd_array = String[julia.exec..., "-i", "--color=yes"]
         append!(kernelcmd_array, julia_options)
         ijulia_dir = get(ENV, "IJULIA_DIR", dirname(@__DIR__)) # support non-Pkg IJulia installs
-        append!(kernelcmd_array, [joinpath(ijulia_dir,"src","kernel.jl"), "{connection_file}"])
+        append!(kernelcmd_array, ["-e", "import IJulia; IJulia.run_kernel()", "{connection_file}"])
 
         ks = Dict(
             "argv" => kernelcmd_array,

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -14,6 +14,12 @@ Changelog](https://keepachangelog.com).
   keyword argument to echo output from Jupyter to the terminal, which can be
   useful when debugging kernels ([#1157]).
 
+### Changed
+- IJulia no longer uses a standalone `kernel.jl` file to launch the kernel, it
+  instead calls a function inside the IJulia module. This means that kernel
+  specs don't use absolute paths anymore and it's not necessary to rebuild
+  IJulia after updating the package ([#1158]).
+
 ### Fixed
 
 - The Julia major and minor version are no longer appended to a custom

--- a/docs/src/manual/installation.md
+++ b/docs/src/manual/installation.md
@@ -37,10 +37,10 @@ at the Julia prompt (or in IJulia).
 If you download and install a new version of Julia from the Julia web
 site, you will also probably want to update the packages with
 `Pkg.update()` (in case newer versions of the packages are required
-for the most recent Julia).  In any case, if you install a new Julia
-binary (or do anything that *changes the location of Julia* on your
-computer), you *must* update the IJulia installation (to tell Jupyter
-where to find the new Julia) by running
+for the most recent Julia).  In any case, if you're using the default kernel and
+you install a new Julia binary (or do anything that *changes the location of
+Julia* on your computer), you *must* update the IJulia installation (to tell
+Jupyter where to find the new Julia) by running:
 ```julia
 Pkg.build("IJulia")
 ```

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -321,5 +321,6 @@ include("execute_request.jl")
 include("handlers.jl")
 include("heartbeat.jl")
 include("inline.jl")
+include("kernel.jl")
 
 end # IJulia

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -1,53 +1,32 @@
-import IJulia
+function run_kernel()
+    # Load InteractiveUtils from the IJulia namespace since @stdlib might not be in LOAD_PATH
+    @eval Main using IJulia.InteractiveUtils
 
-let
-    ijulia_kernel_file = joinpath(dirname(pathof(IJulia)), "kernel.jl")
-    this_kernel_file = @__FILE__
-    if stat(ijulia_kernel_file) != stat(this_kernel_file)
-        @warn "this kernel.jl is different from the one provided by IJulia" this_kernel_file ijulia_kernel_file
+    # the size of truncated output to show should not depend on the terminal
+    # where the kernel is launched, since the display is elsewhere
+    ENV["LINES"] = get(ENV, "LINES", 30)
+    ENV["COLUMNS"] = get(ENV, "COLUMNS", 80)
+
+    IJulia.init(ARGS)
+
+    let startupfile = !isempty(DEPOT_PATH) ? abspath(DEPOT_PATH[1], "config", "startup_ijulia.jl") : ""
+        isfile(startupfile) && Base.JLOptions().startupfile != 2 && Base.include(Main, startupfile)
     end
-end
 
-# Load InteractiveUtils from the IJulia namespace since @stdlib might not be in LOAD_PATH
-using IJulia.InteractiveUtils
+    # import things that we want visible in IJulia but not in REPL's using IJulia
+    @eval Main import IJulia: ans, In, Out, clear_history
 
-# workaround #60:
-if Sys.isapple()
-    ENV["PATH"] = Sys.BINDIR*":"*ENV["PATH"]
-end
+    pushdisplay(IJulia.InlineDisplay())
 
-# the size of truncated output to show should not depend on the terminal
-# where the kernel is launched, since the display is elsewhere
-ENV["LINES"] = get(ENV, "LINES", 30)
-ENV["COLUMNS"] = get(ENV, "COLUMNS", 80)
+    println(IJulia.orig_stdout[], "Starting kernel event loops.")
+    IJulia.watch_stdio()
 
-IJulia.init(ARGS)
-
-let startupfile = !isempty(DEPOT_PATH) ? abspath(DEPOT_PATH[1], "config", "startup_ijulia.jl") : ""
-    isfile(startupfile) && Base.JLOptions().startupfile != 2 && Base.include(Main, startupfile)
-end
-
-# import things that we want visible in IJulia but not in REPL's using IJulia
-import IJulia: ans, In, Out, clear_history
-
-pushdisplay(IJulia.InlineDisplay())
-
-ccall(:jl_exit_on_sigint, Cvoid, (Cint,), 0)
-
-println(IJulia.orig_stdout[], "Starting kernel event loops.")
-IJulia.watch_stdio()
-
-# workaround JuliaLang/julia#4259
-delete!(task_local_storage(),:SOURCE_PATH)
-
-# workaround JuliaLang/julia#6765
-Core.eval(Base, :(is_interactive = true))
-
-# check whether Revise is running and as needed configure it to run before every prompt
-if isdefined(Main, :Revise)
-    let mode = get(ENV, "JULIA_REVISE", "auto")
-        mode == "auto" && IJulia.push_preexecute_hook(Main.Revise.revise)
+    # check whether Revise is running and as needed configure it to run before every prompt
+    if isdefined(Main, :Revise)
+        let mode = get(ENV, "JULIA_REVISE", "auto")
+            mode == "auto" && IJulia.push_preexecute_hook(Main.Revise.revise)
+        end
     end
-end
 
-IJulia.waitloop()
+    IJulia.waitloop()
+end

--- a/test/install.jl
+++ b/test/install.jl
@@ -14,7 +14,7 @@ import IJulia, JSON
                 debugdesc = ccall(:jl_is_debugbuild,Cint,())==1 ? "-debug" : ""
                 @test k["display_name"] == "ijuliatest" * " " * Base.VERSION_STRING * debugdesc
                 @test k["argv"][end] == "{connection_file}"
-                @test k["argv"][end-3:end-2] == ["-O3", "-p2"]
+                @test k["argv"][end-4:end-3] == ["-O3", "-p2"]
                 @test k["language"] == "julia"
                 @test k["env"]["FOO"] == "yes"
             end


### PR DESCRIPTION
This means we don't need to hardcode a path to `kernel.jl` anymore. Also removed some old code from kernel.jl:
- The Apple `PATH` problem was fixed upstream in 2013.
- We set `-i` now so the call to `jl_exit_on_sigint()` and explicitly setting `Base.is_interactive` is no longer necessary (see the docstring for `Base.exit_on_sigint`).
- No need to delete the `SOURCE_PATH` TLV since we can `include()` into a module now.

Fixes #983. Tested manually.

(CC @goerz)