### PR TITLE
Strip whitespace from Pkg commands

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -25,6 +25,7 @@ Changelog](https://keepachangelog.com).
 - The Julia major and minor version are no longer appended to a custom
   `specname` in [`installkernel()`](@ref). The default `specname` that derives
   from `name` and appends the Julia version remains unchanged ([#1154]).
+- Fixed adding multiple packages in Pkg mode ([#1160]).
 
 ## [v1.27.0]
 

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -62,7 +62,7 @@ function execute_request(socket, msg)
 
     # "] ..." cells are interpreted as pkg shell commands
     if occursin(r"^\].*$", code)
-        code = "IJulia.do_pkg_cmd(\"" * escape_string(code[2:end]) * "\")"
+        code = "IJulia.do_pkg_cmd(\"" * escape_string(strip(code[2:end])) * "\")"
     end
 
     # a cell beginning with "? ..." is interpreted as a help request


### PR DESCRIPTION
This avoids a parsing error in Pkg with `] add Foo, Bar`.

Fixes #1095.