### PR TITLE
Print colors in stacktraces by setting an appropriate IOContext

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -19,6 +19,7 @@ Changelog](https://keepachangelog.com).
   instead calls a function inside the IJulia module. This means that kernel
   specs don't use absolute paths anymore and it's not necessary to rebuild
   IJulia after updating the package ([#1158]).
+- Colors in stacktraces are now displayed properly in Jupyter ([#1161]).
 
 ### Fixed
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -166,7 +166,7 @@ function error_content(e, bt=catch_backtrace();
                        msg::AbstractString="")
     tb = map(String, split(sprint(show_bt,
                                         backtrace_top,
-                                        bt, 1:typemax(Int)),
+                                        bt, 1:typemax(Int); context=:color => true),
                                   "\n", keepempty=true))
 
     ename = string(typeof(e))

--- a/src/jupyter.jl
+++ b/src/jupyter.jl
@@ -117,7 +117,6 @@ For launching a JupyterLab instance, see [`IJulia.jupyterlab()`](@ref).
 function notebook(; dir=homedir(), detached=false, port::Union{Nothing,Int}=nothing, verbose=false)
     inited && error("IJulia is already running")
     notebook = find_jupyter_subcommand("notebook", port)
-    @show notebook
     return launch(notebook, dir, detached, verbose)
 end
 

--- a/test/execute_request.jl
+++ b/test/execute_request.jl
@@ -5,8 +5,11 @@ import IJulia
 import IJulia: helpmode, error_content, docdict, get_token
 
 @testset "errors" begin
-    content = error_content(UndefVarError(:a))
+    content = error_content(UndefVarError(:a), backtrace())
     @test "UndefVarError" == content["ename"]
+
+    # Test that ANSI escape codes appear in the traceback for colored output
+    @test occursin("\e[90m", join(content["traceback"], "\n"))
 end
 
 @testset "Inspection" begin


### PR DESCRIPTION
Fixes #1003. Also removed a debugging call to `@show`.