### PR TITLE
Bump version to 1.28.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.27.0"
+version = "1.28.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,7 +7,7 @@ CurrentModule = IJulia
 This documents notable changes in IJulia.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
-## Unreleased
+## [v1.28.0]
 
 ### Added
 - [`notebook()`](@ref) and [`jupyterlab()`](@ref) now support a `verbose`


### PR DESCRIPTION
I've tested the release manually so there should be no regressions :crossed_fingers: Will merge this and tag a new release after CI passes.