### PR TITLE
Fix a deadlock in `shutdown_requests`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.28.0"
+version = "1.28.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,13 @@ CurrentModule = IJulia
 This documents notable changes in IJulia.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v1.28.1]
+
+### Fixed
+
+- Fixed a deadlock in the `shutdown_request` handler that would cause the kernel
+  to hang when exiting ([#1163]).
+
 ## [v1.28.0]
 
 ### Added

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -93,6 +93,8 @@ const capture_stderr = !IJULIA_DEBUG
 set_current_module(m::Module) = current_module[] = m
 const current_module = Ref{Module}(Main)
 
+_shutting_down::Threads.Atomic{Bool} = Threads.Atomic{Bool}(false)
+
 #######################################################################
 include("jupyter.jl")
 #######################################################################


### PR DESCRIPTION
I noticed when testing locally that the kernel would consistently get SIGTERM'd when restarted, turns out that it was always getting into a deadlock when trying to send the `shutdown_reply` message and thus the notebook was forcefully killing it after a timeout. @halleysfifthinc, I wonder if this is the error you were seeing in #1135? The stacktrace from the heartbeat thread is printed too and it's easy to miss the stacktrace from the main thread.

This is a fairly serious bug so if there's no objections I'll merge and release it later today.