### PR TITLE
Kill the Jupyter server properly in notebook() and jupyterlab()

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,13 @@ CurrentModule = IJulia
 This documents notable changes in IJulia.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## Unreleased
+
+### Fixed
+- Fixed handling of the Jupyter process in [`notebook()`](@ref) and
+  [`jupyterlab()`](@ref) when Ctrl + C'ing to shutdown the server, now any
+  running kernels will be cleanly shutdown as well ([#1165]).
+
 ## [v1.28.1]
 
 ### Fixed

--- a/src/jupyter.jl
+++ b/src/jupyter.jl
@@ -71,10 +71,15 @@ function launch(cmd, dir, detached, verbose)
         try
             wait(p)
         catch e
+            # SIGTERM will shutdown the server cleanly in a non-interactive
+            # session. SIGINT will just raise an internal exception and not do
+            # any cleanup if the session isn't interactive (i.e. no stdin or
+            # TTY).
+            kill(p)
+
             if isa(e, InterruptException)
-                kill(p, 2) # SIGINT
+                wait(p)
             else
-                kill(p) # SIGTERM
                 rethrow()
             end
         end


### PR DESCRIPTION
The SIGINT handler is only set in an interactive session, so when running Jupyter through the `notebook()`/`jupyterlab()` functions it will not make Jupyter shutdown all running kernels first. But the SIGTERM handler is always set so we can safely use that to kill the process: https://github.com/jupyter-server/jupyter_server/blob/4ee6e1ddc058f87b2c5699cd6b9caf780a013044/jupyter_server/serverapp.py#L2407

Fixes #977.