### PR TITLE
Improve TTFX

### DIFF
--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -104,7 +104,7 @@ end
     # This dict holds a map from CommID to Comm so that we can
     # pick out the right Comm object when messages arrive
     # from the front-end.
-    comms = Dict{String, CommManager.Comm}()
+    comms::Dict{String, Comm} = Dict{String, Comm}()
 
     postexecute_hooks::Vector{Function} = Function[]
     preexecute_hooks::Vector{Function} = Function[]
@@ -122,7 +122,7 @@ end
     connection_file::Union{String, Nothing} = nothing
     read_stdout::RefValue{Base.PipeEndpoint} = Ref{Base.PipeEndpoint}()
     read_stderr::RefValue{Base.PipeEndpoint} = Ref{Base.PipeEndpoint}()
-    socket_locks = Dict{Socket, ReentrantLock}()
+    socket_locks::Dict{Socket, ReentrantLock} = Dict{Socket, ReentrantLock}()
     sha_ctx::RefValue{SHA.SHA_CTX} = Ref{SHA.SHA_CTX}()
     hmac_key::Vector{UInt8} = UInt8[]
 
@@ -220,9 +220,13 @@ function Base.close(kernel::Kernel)
     IJulia.profile = Dict{String, Any}()
 end
 
-function Kernel(f::Function, profile; kwargs...)
+function Kernel(f::Function, profile::Union{String, Dict}; kwargs...)
     kernel = Kernel(; kwargs...)
-    init([], kernel, profile)
+    if profile isa Dict
+        init([], kernel, profile)
+    else
+        init([profile], kernel)
+    end
 
     try
         f(kernel)

--- a/src/eventloop.jl
+++ b/src/eventloop.jl
@@ -24,7 +24,7 @@ function eventloop(socket, kernel)
                 send_status("busy", kernel, msg)
                 invokelatest(get(handlers, msg.header["msg_type"], unknown_request), socket, kernel, msg)
             catch e
-                if e isa InterruptException && _shutting_down[]
+                if e isa InterruptException && IJulia._shutting_down[]
                     # If we're shutting down, just return immediately
                     return
                 elseif !isa(e, InterruptException)
@@ -42,7 +42,7 @@ function eventloop(socket, kernel)
             end
         end
     catch e
-        if _shutting_down[]
+        if IJulia._shutting_down[]
             return
         end
 

--- a/src/msg.jl
+++ b/src/msg.jl
@@ -14,7 +14,7 @@ msg_header(m::Msg, msg_type::String) = Dict("msg_id" => uuid4(),
                                             "msg_type" => msg_type,
                                             "version" => "5.4")
 
-Base.VersionNumber(m::Msg) = VersionNumber(m.header["version"])
+Base.VersionNumber(m::Msg) = VersionNumber(m.header["version"])::VersionNumber
 
 # PUB/broadcast messages use the msg_type as the ident, except for
 # stream messages which use the stream name (e.g. "stdout").

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -24,46 +24,51 @@ const _TEST_KEY = "a0436f6c-1916-498b-8eb9-e81ab9368e84"
 @compile_workload begin
     local profile = create_profile(45_000; key=_TEST_KEY)
 
-    Kernel(profile; capture_stdout=false, capture_stderr=false, capture_stdin=false) do kernel
-        # Connect as a client to the kernel
-        requests_socket = ZMQ.Socket(ZMQ.DEALER)
-        ip = profile["ip"]
-        port = profile["shell_port"]
-        ZMQ.connect(requests_socket, "tcp://$(ip):$(port)")
+    mktemp() do path, io
+        JSON.print(io, profile)
+        flush(io)
 
-        # kernel_info
-        idents = ["d2bd8e47-b2c9cd130d2967a19f52c1a3"]
-        signature = "3c4f523a0e8b80e5b3e35756d75f62d12b851e1fd67c609a9119872e911f83d2"
-        header = "{\"msg_id\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3_3534705_0\", \"msg_type\": \"kernel_info_request\", \"username\": \"james\", \"session\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3\", \"date\": \"2025-02-20T22:29:47.616834Z\", \"version\": \"5.4\"}"
-        parent_header = "{}"
-        metadata = "{}"
-        content = "{}"
+        Kernel(path; capture_stdout=false, capture_stderr=false, capture_stdin=false) do kernel
+            # Connect as a client to the kernel
+            requests_socket = ZMQ.Socket(ZMQ.DEALER)
+            ip = profile["ip"]
+            port = profile["shell_port"]
+            ZMQ.connect(requests_socket, "tcp://$(ip):$(port)")
 
-        ZMQ.send_multipart(requests_socket, [only(idents), "<IDS|MSG>", signature, header, parent_header, metadata, content])
-        ZMQ.recv_multipart(requests_socket, String)
+            # kernel_info
+            idents = ["d2bd8e47-b2c9cd130d2967a19f52c1a3"]
+            signature = "3c4f523a0e8b80e5b3e35756d75f62d12b851e1fd67c609a9119872e911f83d2"
+            header = "{\"msg_id\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3_3534705_0\", \"msg_type\": \"kernel_info_request\", \"username\": \"james\", \"session\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3\", \"date\": \"2025-02-20T22:29:47.616834Z\", \"version\": \"5.4\"}"
+            parent_header = "{}"
+            metadata = "{}"
+            content = "{}"
 
-        # Execute `42`
-        idents = ["d2bd8e47-b2c9cd130d2967a19f52c1a3"]
-        signature = "758c034ba5efb4fd7fd5a5600f913bc634739bf6a2c1e1d87e88b008706337bc"
-        header = "{\"msg_id\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3_3534705_1\", \"msg_type\": \"execute_request\", \"username\": \"james\", \"session\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3\", \"date\": \"2025-02-20T22:29:49.835131Z\", \"version\": \"5.4\"}"
-        parent_header = "{}"
-        metadata = "{}"
-        content = "{\"code\": \"42\", \"silent\": false, \"store_history\": true, \"user_expressions\": {}, \"allow_stdin\": true, \"stop_on_error\": true}"
+            ZMQ.send_multipart(requests_socket, [only(idents), "<IDS|MSG>", signature, header, parent_header, metadata, content])
+            ZMQ.recv_multipart(requests_socket, String)
 
-        ZMQ.send_multipart(requests_socket, [only(idents), "<IDS|MSG>", signature, header, parent_header, metadata, content])
-        ZMQ.recv_multipart(requests_socket, String)
+            # Execute `42`
+            idents = ["d2bd8e47-b2c9cd130d2967a19f52c1a3"]
+            signature = "758c034ba5efb4fd7fd5a5600f913bc634739bf6a2c1e1d87e88b008706337bc"
+            header = "{\"msg_id\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3_3534705_1\", \"msg_type\": \"execute_request\", \"username\": \"james\", \"session\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3\", \"date\": \"2025-02-20T22:29:49.835131Z\", \"version\": \"5.4\"}"
+            parent_header = "{}"
+            metadata = "{}"
+            content = "{\"code\": \"42\", \"silent\": false, \"store_history\": true, \"user_expressions\": {}, \"allow_stdin\": true, \"stop_on_error\": true}"
 
-        # Execute `error(42)`
-        idents = ["d2bd8e47-b2c9cd130d2967a19f52c1a3"]
-        signature = "953702763b65d9b0505f34ae0eb195574b9c2c65eebedbfa8476150133649801"
-        header = "{\"msg_id\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3_3534705_2\", \"msg_type\": \"execute_request\", \"username\": \"james\", \"session\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3\", \"date\": \"2025-02-20T22:29:50.320836Z\", \"version\": \"5.4\"}"
-        parent_header = "{}"
-        metadata = "{}"
-        content = "{\"code\": \"error(42)\", \"silent\": false, \"store_history\": true, \"user_expressions\": {}, \"allow_stdin\": true, \"stop_on_error\": true}"
+            ZMQ.send_multipart(requests_socket, [only(idents), "<IDS|MSG>", signature, header, parent_header, metadata, content])
+            ZMQ.recv_multipart(requests_socket, String)
 
-        ZMQ.send_multipart(requests_socket, [only(idents), "<IDS|MSG>", signature, header, parent_header, metadata, content])
-        ZMQ.recv_multipart(requests_socket, String)
+            # Execute `error(42)`
+            idents = ["d2bd8e47-b2c9cd130d2967a19f52c1a3"]
+            signature = "953702763b65d9b0505f34ae0eb195574b9c2c65eebedbfa8476150133649801"
+            header = "{\"msg_id\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3_3534705_2\", \"msg_type\": \"execute_request\", \"username\": \"james\", \"session\": \"d2bd8e47-b2c9cd130d2967a19f52c1a3\", \"date\": \"2025-02-20T22:29:50.320836Z\", \"version\": \"5.4\"}"
+            parent_header = "{}"
+            metadata = "{}"
+            content = "{\"code\": \"error(42)\", \"silent\": false, \"store_history\": true, \"user_expressions\": {}, \"allow_stdin\": true, \"stop_on_error\": true}"
 
-        close(requests_socket)
+            ZMQ.send_multipart(requests_socket, [only(idents), "<IDS|MSG>", signature, header, parent_header, metadata, content])
+            ZMQ.recv_multipart(requests_socket, String)
+
+            close(requests_socket)
+        end
     end
 end


### PR DESCRIPTION
Done in two ways:
- Analyzing individual functions with Cthulhu/SnoopCompile to improve type inference. Difficult to benchmark exactly but the precompile workload got about ~30% faster.
- Making the precompile workload load a JSON profile instead of passing it as a Dict. That removes about 230ms from starting the kernel from Jupyter.

Related to #1074. @MasonProtter, @halleysfifthinc, y'all might see a slight improvement from this.