### PR TITLE
Adding default value for `set_max_stdio` keyword argument `kernel`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.30.0"
+version = "1.30.1"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,11 @@ CurrentModule = IJulia
 This documents notable changes in IJulia.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v1.30.1] - 2025-08-27
+
+### Added
+- Added the default value `kernel=_default_kernel` to the function `set_max_stdio`, which fixes a breaking change introduced in v1.30.0 ([#1178])
+
 ## [v1.30.0] - 2025-08-24
 
 ### Added

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -485,7 +485,7 @@ Sets the maximum number of bytes, `max_output`, that can be written to stdout an
 stderr before getting truncated. A large value here allows a lot of output to be
 displayed in the notebook, potentially bogging down the browser.
 """
-function set_max_stdio(max_output::Integer; kernel)
+function set_max_stdio(max_output::Integer; kernel=_default_kernel)
     kernel.max_output_per_request[] = max_output
 end
 


### PR DESCRIPTION
`set_max_stdio` seems to be one of the few (or only) functions that doesn't have a default value for `kernel`, so I added the `_default_kernel` as its default value. I've verified that tests pass.