### PR TITLE
Move the Kernel field out of IJuliaStdio

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.30.2"
+version = "1.30.3"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,12 @@ CurrentModule = IJulia
 This documents notable changes in IJulia.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v1.30.3] - 2025-09-02
+
+### Fixed
+- Modified the internal `IJuliaStdio` struct to be deepcopy-able, which was
+  inadvertently broken in v1.30.0 ([#1180]).
+
 ## [v1.30.2] - 2025-08-29
 
 ### Changed

--- a/src/init.jl
+++ b/src/init.jl
@@ -122,14 +122,14 @@ function init(args, kernel, profile=nothing)
     start_heartbeat(kernel)
     if kernel.capture_stdout
         kernel.read_stdout[], = redirect_stdout()
-        redirect_stdout(IJuliaStdio(stdout, kernel, "stdout"))
+        redirect_stdout(IJuliaStdio(stdout, "stdout"))
     end
     if kernel.capture_stderr
         kernel.read_stderr[], = redirect_stderr()
-        redirect_stderr(IJuliaStdio(stderr, kernel, "stderr"))
+        redirect_stderr(IJuliaStdio(stderr, "stderr"))
     end
     if kernel.capture_stdin
-        redirect_stdin(IJuliaStdio(stdin, kernel, "stdin"))
+        redirect_stdin(IJuliaStdio(stdin, "stdin"))
     end
 
     @static if VERSION < v"1.11"

--- a/src/stdio.jl
+++ b/src/stdio.jl
@@ -7,12 +7,11 @@ Wrapper type around redirected stdio streams, both for overloading things like
 """
 struct IJuliaStdio{IO_t <: IO} <: Base.AbstractPipe
     io::IOContext{IO_t}
-    kernel::Kernel
 end
-IJuliaStdio(io::IO, kernel::Kernel, stream::AbstractString="unknown") =
+IJuliaStdio(io::IO, stream::AbstractString="unknown") =
     IJuliaStdio{typeof(io)}(IOContext(io, :color=>Base.have_color,
                             :jupyter_stream=>stream,
-                            :displaysize=>displaysize()), kernel)
+                            :displaysize=>displaysize()))
 Base.pipe_reader(io::IJuliaStdio) = io.io.io
 Base.pipe_writer(io::IJuliaStdio) = io.io.io
 Base.lock(io::IJuliaStdio) = lock(io.io.io)
@@ -269,5 +268,5 @@ import Base.flush
 function flush(io::IJuliaStdio)
     flush(io.io)
     oslibuv_flush()
-    send_stream(get(io,:jupyter_stream,"unknown"), io.kernel)
+    send_stream(get(io,:jupyter_stream,"unknown"), IJulia._default_kernel)
 end

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -393,7 +393,7 @@ end
                     shutdown(client; wait=false)
                 end
 
-                @test timedwait(() -> process_exited(kernel_proc), 10) == :ok
+                @test timedwait(() -> process_exited(kernel_proc), 30) == :ok
             finally
                 kill(kernel_proc)
             end

--- a/test/stdio.jl
+++ b/test/stdio.jl
@@ -3,27 +3,21 @@ using IJulia
 
 @testset "stdio" begin
     kernel = IJulia.Kernel()
+    # Set _default_kernel so that flush(::IJuliaStdio) works
+    IJulia._default_kernel = kernel
 
     mktemp() do path, io
-        redirect_stdout(IJulia.IJuliaStdio(io, kernel, "stdout")) do
+        redirect_stdout(IJulia.IJuliaStdio(io, "stdout")) do
             println(Base.stdout, "stdout")
             println("print")
         end
         flush(io)
         seek(io, 0)
         @test read(io, String) == "stdout\nprint\n"
-        if VERSION < v"1.7.0-DEV.254"
-            @test_throws ArgumentError redirect_stdout(IJulia.IJuliaStdio(io, kernel, "stderr"))
-            @test_throws ArgumentError redirect_stdout(IJulia.IJuliaStdio(io, kernel, "stdin"))
-            @test_throws ArgumentError redirect_stderr(IJulia.IJuliaStdio(io, kernel, "stdout"))
-            @test_throws ArgumentError redirect_stderr(IJulia.IJuliaStdio(io, kernel, "stdin"))
-            @test_throws ArgumentError redirect_stdin(IJulia.IJuliaStdio(io, kernel, "stdout"))
-            @test_throws ArgumentError redirect_stdin(IJulia.IJuliaStdio(io, kernel, "stderr"))
-        end
     end
 
     mktemp() do path, io
-        redirect_stderr(IJulia.IJuliaStdio(io, kernel, "stderr")) do
+        redirect_stderr(IJulia.IJuliaStdio(io, "stderr")) do
             println(Base.stderr, "stderr")
         end
         flush(io)
@@ -32,7 +26,7 @@ using IJulia
     end
 
     mktemp() do path, io
-        redirect_stdin(IJulia.IJuliaStdio(io, kernel, "stdin")) do
+        redirect_stdin(IJulia.IJuliaStdio(io, "stdin")) do
             # We can't actually do anything here because `IJuliaexecute_msg` has not
             # yet been initialized, so we just make sure that redirect_stdin does
             # not error.
@@ -42,4 +36,12 @@ using IJulia
     kernel.stdio_bytes = 42
     IJulia.reset_stdio_count(kernel)
     @test kernel.stdio_bytes == 0
+
+    # Test that the IJuliaStdio object is deepcopy-able. See:
+    # https://github.com/JuliaLang/IJulia.jl/issues/1179
+    mktemp() do path, io
+        deepcopy(IJulia.IJuliaStdio(io, "stdout"))
+    end
+
+    IJulia._default_kernel = nothing
 end


### PR DESCRIPTION
This makes it possible to `deepcopy()` the struct.

Fixes #1179.