### PR TITLE
Fix behaviour of In/Out and bump version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.30.3"
+version = "1.30.4"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,13 @@ CurrentModule = IJulia
 This documents notable changes in IJulia.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v1.30.4] - 2025-09-08
+
+### Fixed
+- Fixed usage of [`In`](@ref) and [`Out`](@ref) so that they actually contain
+  the cell history instead of just being empty ([#1182]). This was accidentally
+  broken in v1.30.0.
+
 ## [v1.30.3] - 2025-09-02
 
 ### Fixed
@@ -24,7 +31,7 @@ Changelog](https://keepachangelog.com).
 
 ### Fixed
 - Added the default value `kernel=_default_kernel` to the function
-  `set_max_stdio`, which fixes a breaking change introduced in v1.30.0
+  [`set_max_stdio`](@ref), which fixes a breaking change introduced in v1.30.0
   ([#1178]).
 
 ## [v1.30.0] - 2025-08-24

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -169,12 +169,6 @@ function Base.setproperty!(kernel::Kernel, name::Symbol, x)
     # These fields need to be assigned explicitly to their global counterparts
     if name ∈ (:ans, :n, :In, :Out, :inited)
         setproperty!(IJulia, name, x)
-
-        if name ∈ (:ans, :In, :Out)
-            if hasproperty(kernel.current_module, name)
-                setproperty!(kernel.current_module, name, x)
-            end
-        end
     end
 
     setfield!(kernel, name, x)
@@ -224,8 +218,10 @@ function Base.close(kernel::Kernel)
     wait(kernel)
 
     # Reset global variables
-    IJulia.ans = nothing
     IJulia.n = 0
+    IJulia.ans = nothing
+    IJulia.In = Dict{Int, String}()
+    IJulia.Out = Dict{Int, Any}()
     IJulia._default_kernel = nothing
     IJulia.CommManager.comms = Dict{String, CommManager.Comm}()
     IJulia.profile = Dict{String, Any}()
@@ -322,13 +318,13 @@ load(filename::AbstractString, replace::Bool=false, kernel=_default_kernel) =
 returns the string for input cell `n` of the notebook (as it was
 when it was *last evaluated*).
 """
-In::Dict{String, Any} = Dict{String, Any}()
+In::Dict{Int, String} = Dict{Int, String}()
 """
 `Out` is a global dictionary of output values, where `Out[n]`
 returns the output from the last evaluation of cell `n` in the
 notebook.
 """
-Out::Dict{String, Any} = Dict{String, Any}()
+Out::Dict{Int, Any} = Dict{Int, Any}()
 """
 `ans` is a global variable giving the value returned by the last
 notebook cell evaluated.

--- a/src/init.jl
+++ b/src/init.jl
@@ -148,5 +148,11 @@ function init(args, kernel, profile=nothing)
     send_status("starting", kernel)
     kernel.inited = true
 
+    # Explicitly initialize these fields so that setproperty!(::Kernel) is
+    # called and assigns them to their corresponding global variables. This is
+    # not done by the @kwdef constructor.
+    kernel.In = Dict{Int, String}()
+    kernel.Out = Dict{Int, Any}()
+
     kernel.waitloop_task[] = @async waitloop(kernel)
 end


### PR DESCRIPTION
Previously the dictionaries were not copied properly with their global counterparts, meaning that they would never get updated.

Fixes one of the issues from #1181. This is quite a serious bug so I'm gonna go ahead and merge and tag a release.