### PR TITLE
Add juliaup integration to add kernels for minor versions by default

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -20,6 +20,12 @@ Changelog](https://keepachangelog.com).
   Julia 1.12.
 - Switched the default matplotlib backend for [`IJulia.init_matplotlib()`](@ref)
   to `widget`, which should be more backwards compatible ([#1205]).
+- IJulia now checks if juliaup is used during the build step when installing the
+  default kernel, and if it is used then it will set the kernel command to the
+  equivalent of `julia +major.minor` ([#1201]). This has the advantage of not
+  needing to rebuild IJulia to update the kernel after every patch release of
+  Julia, but it does mean that IJulia will only create kernels for each Julia
+  minor release instead of each patch release.
 
 ## [v1.31.1] - 2025-10-20
 

--- a/docs/src/manual/installation.md
+++ b/docs/src/manual/installation.md
@@ -62,16 +62,22 @@ Pkg.update()
 If you download and install a new version of Julia from the Julia web
 site, you will also probably want to update the packages with
 `Pkg.update()` (in case newer versions of the packages are required
-for the most recent Julia).  In any case, if you install a new Julia
-binary (or do anything that *changes the location of Julia* on your
-computer), you *must* update the IJulia installation (to tell Jupyter
-where to find the new Julia) by running
+for the most recent Julia). If you're using juliaup to manage Julia, then for
+every Julia *minor release* you will need to explicitly update the IJulia
+installation to tell Jupyter where to find the new Julia version:
 ```julia
 Pkg.build("IJulia")
 ```
 
-!!! important
+This is because IJulia creates default kernels for every minor version if
+juliaup is used.
 
+If you are not using juliaup to manage Julia, then you *must* update the IJulia
+installation every time you install a new Julia binary (or do anything that
+*changes the location of Julia* on your computer).
+
+
+!!! important
     `Pkg.build("IJulia")` **must** be run at the Julia command line.
     It will error and fail if run within IJulia.
 

--- a/test/install.jl
+++ b/test/install.jl
@@ -4,7 +4,7 @@ import IJulia: JSONX
 
 @testset "installkernel" begin
     let kspec = IJulia.installkernel("ijuliatest", "-O3", "-p2",
-                    env=Dict("FOO"=>"yes"), specname="Yef1rLr4kXKxq9rbEh3m")
+                                     env=Dict("FOO"=>"yes"), specname="Yef1rLr4kXKxq9rbEh3m")
         try
             @test basename(kspec) == "Yef1rLr4kXKxq9rbEh3m"  # should not contain Julia version suffix
             @test dirname(kspec) == IJulia.kerneldir()
@@ -13,7 +13,7 @@ import IJulia: JSONX
             @test isfile(joinpath(kspec, "logo-64x64.png"))
             let k = JSONX.parsefile(joinpath(kspec, "kernel.json"))
                 debugdesc = ccall(:jl_is_debugbuild,Cint,())==1 ? "-debug" : ""
-                @test k["display_name"] == "ijuliatest" * " " * Base.VERSION_STRING * debugdesc
+                @test k["display_name"] == "ijuliatest $(VERSION.major).$(VERSION.minor)$(debugdesc)"
                 @test k["argv"][end] == "{connection_file}"
                 @test k["argv"][end-4:end-3] == ["-O3", "-p2"]
                 @test k["language"] == "julia"
@@ -35,4 +35,10 @@ import IJulia: JSONX
             rm(kspec, force=true, recursive=true)
         end
     end
+
+    # Test juliaup detection
+    julia_exe = IJulia.exe("julia")
+    @test IJulia.julia_cmd("bin") == `$(joinpath("bin", julia_exe))`
+    juliaup_dir = joinpath("foo", "juliaup")
+    @test IJulia.julia_cmd(juliaup_dir) == `$(joinpath(juliaup_dir, "bin", julia_exe)) +$(VERSION.major).$(VERSION.minor)`
 end


### PR DESCRIPTION
I'm not quite convinced we should go for only one kernel pointing to the juliaup default since sometimes it's handy to switch between versions, but this seems like a safe middle-ground.