### PR TITLE
Switch the default matplotlib backend to `widget`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ ZMQ = "c2297ded-f4af-51ae-bb23-16f91089e4e1"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [extensions]
-PythonCallExt = "PythonCall"
+IJuliaPythonCallExt = "PythonCall"
 
 [compat]
 Base64 = "1"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -18,6 +18,8 @@ Changelog](https://keepachangelog.com).
   lets us remove one more dependency and remove all of the invalidations caused
   by JSON.jl. Load time is also slightly improved, from ~0.08s to ~0.05s on
   Julia 1.12.
+- Switched the default matplotlib backend for [`IJulia.init_matplotlib()`](@ref)
+  to `widget`, which should be more backwards compatible ([#1205]).
 
 ## [v1.31.1] - 2025-10-20
 

--- a/ext/IJuliaPythonCallExt.jl
+++ b/ext/IJuliaPythonCallExt.jl
@@ -5,7 +5,7 @@
 # interfaces it specifies we can get full support for ipywidgets and all other
 # libraries that use ipywidgets (like matplotlib/ipympl).
 
-module PythonCallExt
+module IJuliaPythonCallExt
 
 import IJulia
 using PythonCall
@@ -225,7 +225,7 @@ function IJulia.init_ipywidgets()
     nothing
 end
 
-function IJulia.init_matplotlib(backend::String="ipympl")
+function IJulia.init_matplotlib(backend::String="widget")
     IJulia.init_ipywidgets()
 
     # Make sure it's in interactive mode and it's using the backend

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -551,7 +551,7 @@ Julia's `display()` instead.
 function init_ipython end
 
 """
-    init_matplotlib()
+    init_matplotlib(backend="widget")
 
 Initialize the integration with matplotlib.
 """

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -446,7 +446,7 @@ end
     end
 
     @testset "Utilities" begin
-        ext = Base.get_extension(IJulia, :PythonCallExt)
+        ext = Base.get_extension(IJulia, :IJuliaPythonCallExt)
 
         x = Dict(1 => Dict{Int, Any}(2 => [1, 2]), "foo" => "bar")
         ext.arrays_to_pylist!(x)


### PR DESCRIPTION
This has better backwards compatibility. Also renamed the extension to `IJuliaPythonCallExt` to be clearer when precompiling.