### PR TITLE
permit more python versions

### DIFF
--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -13,6 +13,9 @@ Changelog](https://keepachangelog.com).
 - Fixed the display of `UnionAll` types such as `Pair.body` ([#1203]).
 - Fixed a bug in the PythonCall extension that would break opening comms from
   the frontend side ([#1206]).
+- The PythonCall extension accidentally forced some test dependencies to be
+  installed outside of the tests, now they have been fully moved into the test
+  suite ([#1209]).
 
 ### Changed
 - Replaced JSON.jl with a vendored copy of

--- a/test/CondaPkg.toml
+++ b/test/CondaPkg.toml
@@ -7,4 +7,4 @@ jupyter_client = ""
 ipympl = ""
 comm = ""
 # Python 3.14 segfaults something awful
-python = "3.13.*"
+python = "<3.14"

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -1,3 +1,8 @@
+# Copy CondaPkg.toml to the test project so that it gets found by CondaPkg
+# during the tests. If this was instead in the project directory it would also
+# be used by CondaPkg outside of the tests, which we don't want.
+cp(joinpath(@__DIR__, "CondaPkg.toml"), joinpath(dirname(Base.active_project()), "CondaPkg.toml"))
+
 ENV["JULIA_CONDAPKG_ENV"] = "@ijulia-tests"
 ENV["JULIA_CONDAPKG_VERBOSITY"] = -1
 


### PR DESCRIPTION
Many important scientific packages do not yet work on python 3.13. By relaxing this constraint, wrappers like PyQDecoders.jl can be used together with IJulia.

Tested locally.

Before this change `add PyQDecoders IJulia` would fail at the conda resolve step.