### PR TITLE
make an ijulia "app" entrypoint

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,6 +2,9 @@ name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 version = "1.32.0"
 
+[apps]
+ijulia = {}
+
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"

--- a/README.md
+++ b/README.md
@@ -40,15 +40,24 @@ Note that `IJulia` should generally be installed in Julia's global package envir
 install a custom kernel that specifies a particular environment.
 
 Alternatively, you can have IJulia create and manage its own Python/Jupyter installation.
-To do this, type the following in Julia, at the `julia>` prompt:
 
+**With Julia 1.12+**, you can launch IJulia directly from the command line. First install the app entry point:
+```julia
+pkg> app add IJulia
+```
+Then run:
+```bash
+ijulia --help
+```
+
+**With Julia 1.10-1.11**, type the following in Julia, at the `julia>` prompt:
 ```julia
 using IJulia
 notebook()
 ```
 
 to launch the IJulia notebook in your browser.
-The first time you run `notebook()`, it will prompt you
+The first time you run `notebook()` or `ijulia`, it will prompt you
 for whether it should install Jupyter.  Hit enter to
 have it use the [Conda.jl](https://github.com/Luthaf/Conda.jl)
 package to install a minimal Python+Jupyter distribution (via

--- a/docs/src/manual/running.md
+++ b/docs/src/manual/running.md
@@ -3,11 +3,13 @@
 
 ## Command-Line Launcher
 
-Starting with Julia 1.12, you can launch IJulia directly from the command line using the `ijulia` command. First, you need to install the app entry point by running in the Julia REPL:
+Starting with Julia 1.12, you can launch IJulia directly from the command line using the `ijulia` command. First, you need to install the app entry point (see [Julia app documentation](https://pkgdocs.julialang.org/v1/apps/)) by running in the Julia REPL:
 
 ```julia
 pkg> app add IJulia
 ```
+
+You may need to add `~/.julia/bin` to your PATH if it's not already there.
 
 Then you can use the `ijulia` command from your terminal:
 

--- a/docs/src/manual/running.md
+++ b/docs/src/manual/running.md
@@ -1,6 +1,45 @@
 # Running IJulia
 
 
+## Command-Line Launcher
+
+Starting with Julia 1.12, you can launch IJulia directly from the command line using the `ijulia` command. First, you need to install the app entry point by running in the Julia REPL:
+
+```julia
+pkg> app add IJulia
+```
+
+Then you can use the `ijulia` command from your terminal:
+
+```bash
+ijulia
+```
+
+This provides a convenient way to launch Jupyter without starting a Julia REPL session first. The launcher supports the following options:
+
+- `ijulia` or `ijulia notebook` - Launch Jupyter Notebook (default)
+- `ijulia lab` - Launch JupyterLab
+- `--dir=PATH` - Launch in the specified directory (default: home directory)
+- `--port=N` - Open on the specified port number
+- `--detached` - Run in detached mode (continues after Julia exits)
+- `--verbose` - Enable verbose output from Jupyter
+- `--help, -h` - Show help message
+
+Any additional arguments are passed directly to the jupyter command.
+
+**Examples:**
+```bash
+# Launch notebook in a specific directory
+ijulia --dir=/path/to/project
+
+# Launch JupyterLab on a specific port
+ijulia lab --port=8888 --detached
+
+# Pass additional arguments to Jupyter
+ijulia --no-browser
+```
+
+
 ## Running the IJulia Notebook
 
 If you are comfortable managing your own Python/Jupyter installation, you can just run `jupyter notebook` yourself in a terminal.   To simplify installation, however, you can alternatively type the following in Julia, at the `julia>` prompt:

--- a/src/IJulia.jl
+++ b/src/IJulia.jl
@@ -587,11 +587,8 @@ include("precompile.jl")
 #######################################################################
 # App entry point for `ijulia` command
 
-# Mutable function references for testing - allows tests to mock these functions
-notebook_cmd::Function = notebook
-jupyterlab_cmd::Function = jupyterlab
-
-function (@main)(ARGS)
+@static if VERSION >= v"1.11"
+function (@main)(ARGS; notebook_cmd::Function = notebook, jupyterlab_cmd::Function = jupyterlab)
     # Show help if help flag
     if !isempty(ARGS) && ARGS[1] in ("--help", "-h", "help")
         println("""
@@ -621,8 +618,8 @@ function (@main)(ARGS)
         return 0
     end
 
-    # Parse subcommand (default to "notebook")
-    subcommand = "notebook"
+    # Parse subcommand (default to "lab")
+    subcommand = "lab"
     args_start = 1
     if !isempty(ARGS)
         first_arg = ARGS[1]
@@ -660,7 +657,7 @@ function (@main)(ARGS)
     # Launch the appropriate command
     launch_func = subcommand == "notebook" ? notebook_cmd : jupyterlab_cmd
     try
-        launch_func(Cmd(extra_args); dir=dir, detached=detached, port=port, verbose=verbose)
+        launch_func(Cmd(extra_args); dir, detached, port, verbose)
         return 0
     catch e
         if e isa InterruptException
@@ -671,5 +668,6 @@ function (@main)(ARGS)
         end
     end
 end
+end # if VERSION
 
 end # IJulia

--- a/test/main.jl
+++ b/test/main.jl
@@ -1,0 +1,127 @@
+using Test
+import IJulia
+
+@testset "@main app entry point" begin
+    # Test help output
+    @testset "help" begin
+        # Capture stdout using a pipe
+        old_stdout = stdout
+        rd, wr = redirect_stdout()
+
+        ret = IJulia.main(["--help"])
+
+        # Restore stdout and read the captured output
+        redirect_stdout(old_stdout)
+        close(wr)
+        help_text = read(rd, String)
+        close(rd)
+
+        @test ret == 0
+        @test occursin("IJulia Launcher", help_text)
+        @test occursin("notebook", help_text)
+        @test occursin("lab", help_text)
+        @test occursin("--dir=PATH", help_text)
+        @test occursin("--port=N", help_text)
+        @test occursin("--detached", help_text)
+        @test occursin("--verbose", help_text)
+    end
+
+    # Test invalid subcommand
+    @testset "invalid subcommand" begin
+        ret = @test_logs (:error, r"Unknown subcommand.*Use 'notebook' or 'lab'") IJulia.main(["invalid"])
+        @test ret == 1
+    end
+
+    # Test argument parsing without actually launching
+    # We use mutable function references (notebook_cmd/jupyterlab_cmd) to test parsing
+    @testset "argument parsing" begin
+        # Save original functions
+        orig_notebook = IJulia.notebook_cmd
+        orig_jupyterlab = IJulia.jupyterlab_cmd
+
+        # Test notebook (default)
+        called_with = nothing
+        IJulia.notebook_cmd = function(args=``; dir=homedir(), detached=false, port=nothing, verbose=false)
+            called_with = (; args, dir, detached, port, verbose)
+            return nothing
+        end
+
+        try
+            ret = IJulia.main(["--dir=/test", "--port=9999", "--detached", "--verbose", "--no-browser"])
+            @test ret == 0
+            @test !isnothing(called_with)
+            @test called_with.dir == "/test"
+            @test called_with.port == 9999
+            @test called_with.detached == true
+            @test called_with.verbose == true
+            @test "--no-browser" in called_with.args
+        finally
+            IJulia.notebook_cmd = orig_notebook
+        end
+
+        # Test explicit notebook subcommand
+        called_with = nothing
+        IJulia.notebook_cmd = function(args=``; dir=homedir(), detached=false, port=nothing, verbose=false)
+            called_with = (; args, dir, detached, port, verbose)
+            return nothing
+        end
+
+        try
+            ret = IJulia.main(["notebook", "--port=8888"])
+            @test ret == 0
+            @test !isnothing(called_with)
+            @test called_with.port == 8888
+            @test called_with.dir == homedir()
+            @test called_with.detached == false
+        finally
+            IJulia.notebook_cmd = orig_notebook
+        end
+
+        # Test lab subcommand
+        called_with = nothing
+        IJulia.jupyterlab_cmd = function(args=``; dir=homedir(), detached=false, port=nothing, verbose=false)
+            called_with = (; args, dir, detached, port, verbose)
+            return nothing
+        end
+
+        try
+            ret = IJulia.main(["lab", "--dir=/lab", "--verbose"])
+            @test ret == 0
+            @test !isnothing(called_with)
+            @test called_with.dir == "/lab"
+            @test called_with.verbose == true
+        finally
+            IJulia.jupyterlab_cmd = orig_jupyterlab
+        end
+    end
+
+    # Test InterruptException handling
+    @testset "interrupt handling" begin
+        orig_notebook = IJulia.notebook_cmd
+        IJulia.notebook_cmd = function(args=``; kwargs...)
+            throw(InterruptException())
+        end
+
+        try
+            ret = IJulia.main([])
+            @test ret == 0  # InterruptException should return 0
+        finally
+            IJulia.notebook_cmd = orig_notebook
+        end
+    end
+
+    # Test error handling
+    @testset "error handling" begin
+        orig_notebook = IJulia.notebook_cmd
+        IJulia.notebook_cmd = function(args=``; kwargs...)
+            error("Test error")
+        end
+
+        try
+            ret = @test_logs (:error, r"Failed to launch") IJulia.main([])
+            @test ret == 1  # Errors should return 1
+        finally
+            IJulia.notebook_cmd = orig_notebook
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,10 @@ const TEST_FILES = [
     "inline.jl", "completion.jl", "jsonx.jl"
 ]
 
+if VERSION >= v"1.11"
+    push!(TEST_FILES, "main.jl")
+end
+
 for file in TEST_FILES
     println(file)
     include(file)


### PR DESCRIPTION
this makes ijulia installable via the Pkg app interface: https://pkgdocs.julialang.org/v1/apps/ and allows one to do e.g.

```
pkg> app add IJulia
```

and then run e.g.

```
ijulia lab
```

in the terminal to start an ijulia jupyterlab notebook without having to launch julia itself and load IJulia explicitly.

To test this PR you can do `Pkg.Apps.develop(path=abspath("."))` (the relative path is currently bugged), make sure `.julia/bin` is in the PATH and then run `ijulia`.
