### PR TITLE
Use `Base.julia_cmd()` instead of `Base.JLOptions()`

### DIFF
--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -482,17 +482,7 @@ end
         mktemp() do connection_file, io
             # Write the connection file
             jupyter_client_lib.connect.write_connection_file(; fname=connection_file, profile_kwargs...)
-
-            check_bounds = let arg = Base.JLOptions().check_bounds
-                if arg == 0
-                    "auto"
-                elseif arg == 1
-                    "yes"
-                else
-                    "no"
-                end
-            end
-            cmd = `$julia --startup-file=no --check-bounds=$(check_bounds) --project=$(Base.active_project()) -e 'import IJulia; IJulia.run_kernel()' $(connection_file)`
+            cmd = `$(Base.julia_cmd()) --project=$(Base.active_project()) -e 'import IJulia; IJulia.run_kernel()' $(connection_file)`
             kernel_proc = run(pipeline(cmd; stdout, stderr); wait=false)
             try
                 jupyter_client(profile) do client


### PR DESCRIPTION
This should include whatever `--check-bounds` option is passed.