### PR TITLE
Match the REPL's exception behaviour

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.33.0"
+version = "1.34.0"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,6 +7,13 @@ CurrentModule = IJulia
 This documents notable changes in IJulia.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v1.34.0] - 2026-01-18
+
+### Changed
+- IJulia now handles exceptions like the REPL: types will be limited by default
+  and the `err` variable will be set appropriately for those who want to display
+  the full error ([#1237).
+
 ## [v1.33.0] - 2025-11-22
 
 ### Added

--- a/ext/IJuliaPythonCallExt.jl
+++ b/ext/IJuliaPythonCallExt.jl
@@ -26,7 +26,7 @@ end
 # *only* want the Python stacktrace to be printed so we pass `backtrace=true`
 # but give an empty vector as a backtrace so that the Julia backtrace is not
 # printed twice.
-IJulia.showerror_nobt(io, e::PyException, _) = showerror(io, e, []; backtrace=true)
+IJulia.custom_showerror(io, e::PyException, _) = showerror(io, e, []; backtrace=true)
 
 function recursive_pyconvert(x)
     x_type = pyconvert(String, pytype(x).__name__)

--- a/src/execute_request.jl
+++ b/src/execute_request.jl
@@ -195,6 +195,13 @@ function execute_request(socket, kernel, msg)
         empty!(kernel.execute_payloads)
     catch e
         bt = catch_backtrace()
+
+        # Set the `err` variable like the REPL does, so users can call show(err) for full types
+        errstack = scrub_backtrace(current_exceptions())
+        if !Base.istrivialerror(errstack)
+            setglobal!(Base.MainInclude, :err, errstack)
+        end
+
         try
             # flush pending stdio
             flush_all()


### PR DESCRIPTION
Namely by limiting types in stacktraces and setting the `err` variable.