### PR TITLE
Revert to standard data directory on Mac

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "IJulia"
 uuid = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
-version = "1.34.1"
+version = "1.34.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/deps/kspec.jl
+++ b/deps/kspec.jl
@@ -43,11 +43,7 @@ copy_config(src::AbstractString, dest::AbstractString) = cp(src, joinpath(dest, 
         return !isempty(APPDATA) ? joinpath(APPDATA, "jupyter") : joinpath(get(ENV, "JUPYTER_CONFIG_DIR", joinpath(homedir(), ".jupyter")), "data")
     end
 elseif Sys.isapple()
-  function default_jupyter_data_dir()
-    modern = joinpath(homedir(), "Library", "Application Support", "Jupyter")
-    legacy = joinpath(homedir(), "Library", "Jupyter")
-    return isdir(legacy) && !isdir(modern) ? legacy : modern
-  end
+    default_jupyter_data_dir() = joinpath(homedir(), "Library", "Jupyter")
 else
     function default_jupyter_data_dir()
         xdg_data_home = get(ENV, "XDG_DATA_HOME", "")

--- a/docs/src/_changelog.md
+++ b/docs/src/_changelog.md
@@ -7,10 +7,16 @@ CurrentModule = IJulia
 This documents notable changes in IJulia.jl. The format is based on [Keep a
 Changelog](https://keepachangelog.com).
 
+## [v1.34.2] - 2026-02-08
+
+### Changed
+- The change to the default Jupyter directory in v1.34.1 was reverted since the
+  new directory turned out to not be used by default ([#1240]).
+
 ## [v1.34.1] - 2026-01-26
 
 ### Changed
-* Prioritize `~/Library/Application Support/Jupyter` on macOS for modern Jupyter compatibility ([#1238]).
+- Prioritize `~/Library/Application Support/Jupyter` on macOS for modern Jupyter compatibility ([#1238]).
 
 ## [v1.34.0] - 2026-01-18
 


### PR DESCRIPTION
Turns out that this was never the default behaviour, and it's not planned to be the default in the future: https://github.com/jupyter/jupyter_core/pull/447

@arafune, maybe your system is configured differently? Jupyter does allow opting in to using platformdirs.